### PR TITLE
fix(index): dedupe chunk IDs before upsert to avoid UNIQUE constraint

### DIFF
--- a/crates/context-index/src/structural/store.rs
+++ b/crates/context-index/src/structural/store.rs
@@ -341,7 +341,22 @@ pub fn upsert_parsed_file(conn: &mut Connection, pf: &ParsedFile, size_bytes: u6
             ],
         )?;
     }
-    for c in &pf.chunks {
+    // Defensive dedupe for chunks as well (large vendor JS can produce duplicate chunk ids)
+    let mut seen_chunks = std::collections::HashSet::new();
+    let chunks: Vec<&crate::structural::types::Chunk> = pf
+        .chunks
+        .iter()
+        .filter(|c| seen_chunks.insert(c.id.clone()))
+        .collect();
+    if chunks.len() < pf.chunks.len() {
+        tracing::warn!(
+            file = %pf.file,
+            total = %pf.chunks.len(),
+            unique = %chunks.len(),
+            "deduplicated chunk ids before upsert"
+        );
+    }
+    for c in chunks {
         tx.execute(
             "INSERT INTO chunks (id, file, language, start_line, end_line, start_byte, end_byte, parent_symbol, content_hash, text_size_bytes) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
             params![
@@ -942,5 +957,94 @@ mod tests {
             .query_row("SELECT hash FROM files WHERE path='a.py'", [], |r| r.get(0))
             .unwrap();
         assert_eq!(hash, "hash_good", "hash should remain last-good");
+    }
+
+    #[test]
+    fn dedup_chunk_ids_before_upsert() {
+        // Reproduce duplicate chunk IDs (e.g., vendor JS with overlapping chunks)
+        let mut conn = open_in_memory().unwrap();
+        let lang = crate::structural::language::Language::Python;
+        let dup_id = "dup_chunk_id_123".to_string();
+        let unique_id = "unique_chunk_id_456".to_string();
+        let chunk_a = crate::structural::types::Chunk {
+            id: dup_id.clone(),
+            file: "a.py".into(),
+            language: lang,
+            start_line: 1,
+            end_line: 2,
+            start_byte: 0,
+            end_byte: 10,
+            parent_symbol: None,
+            content_hash: "hash_a".into(),
+            text_size_bytes: 10,
+        };
+        // Duplicate ID, different position/content but same ID -> should be deduped
+        let chunk_b = crate::structural::types::Chunk {
+            id: dup_id.clone(),
+            file: "a.py".into(),
+            language: lang,
+            start_line: 3,
+            end_line: 4,
+            start_byte: 20,
+            end_byte: 30,
+            parent_symbol: None,
+            content_hash: "hash_b".into(),
+            text_size_bytes: 10,
+        };
+        let chunk_c = crate::structural::types::Chunk {
+            id: unique_id.clone(),
+            file: "a.py".into(),
+            language: lang,
+            start_line: 5,
+            end_line: 6,
+            start_byte: 40,
+            end_byte: 50,
+            parent_symbol: None,
+            content_hash: "hash_c".into(),
+            text_size_bytes: 10,
+        };
+        let pf = crate::structural::types::ParsedFile {
+            file: "a.py".into(),
+            language: lang,
+            content_hash: "file_hash".into(),
+            symbols: vec![],
+            references: vec![],
+            imports: vec![],
+            chunks: vec![chunk_a, chunk_b, chunk_c],
+            parse_error: None,
+        };
+        // Should succeed despite duplicate IDs
+        upsert_parsed_file(&mut conn, &pf, 100).unwrap();
+        // Exactly one dup_id and one unique_id should persist, total 2
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks WHERE file='a.py'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            count, 2,
+            "duplicate chunk ID should be deduped to 1, plus unique"
+        );
+        let dup_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM chunks WHERE id=?1",
+                params![dup_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dup_count, 1, "exactly one dup_id should remain");
+        let uniq_exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM chunks WHERE id=?1)",
+                params![unique_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(uniq_exists, "unique chunk should remain");
+        // Ensure no unrelated chunk lost: query all chunks
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(total, 2);
     }
 }

--- a/crates/context-index/src/structural/store.rs
+++ b/crates/context-index/src/structural/store.rs
@@ -961,11 +961,12 @@ mod tests {
 
     #[test]
     fn dedup_chunk_ids_before_upsert() {
-        // Reproduce duplicate chunk IDs (e.g., vendor JS with overlapping chunks)
+        // Production chunk_id = blake3(file, start_byte, end_byte, content_hash)
+        // So a real duplicate is an ACTUAL identical duplicate (same file/range/hash -> same ID)
         let mut conn = open_in_memory().unwrap();
         let lang = crate::structural::language::Language::Python;
-        let dup_id = "dup_chunk_id_123".to_string();
-        let unique_id = "unique_chunk_id_456".to_string();
+        let content_hash_a = "hash_a".to_string();
+        let dup_id = crate::structural::types::chunk_id("a.py", 0, 10, &content_hash_a);
         let chunk_a = crate::structural::types::Chunk {
             id: dup_id.clone(),
             file: "a.py".into(),
@@ -975,22 +976,13 @@ mod tests {
             start_byte: 0,
             end_byte: 10,
             parent_symbol: None,
-            content_hash: "hash_a".into(),
+            content_hash: content_hash_a.clone(),
             text_size_bytes: 10,
         };
-        // Duplicate ID, different position/content but same ID -> should be deduped
-        let chunk_b = crate::structural::types::Chunk {
-            id: dup_id.clone(),
-            file: "a.py".into(),
-            language: lang,
-            start_line: 3,
-            end_line: 4,
-            start_byte: 20,
-            end_byte: 30,
-            parent_symbol: None,
-            content_hash: "hash_b".into(),
-            text_size_bytes: 10,
-        };
+        // Actual identical duplicate
+        let chunk_b = chunk_a.clone();
+        let content_hash_c = "hash_c".to_string();
+        let unique_id = crate::structural::types::chunk_id("a.py", 40, 50, &content_hash_c);
         let chunk_c = crate::structural::types::Chunk {
             id: unique_id.clone(),
             file: "a.py".into(),
@@ -1000,7 +992,7 @@ mod tests {
             start_byte: 40,
             end_byte: 50,
             parent_symbol: None,
-            content_hash: "hash_c".into(),
+            content_hash: content_hash_c.clone(),
             text_size_bytes: 10,
         };
         let pf = crate::structural::types::ParsedFile {
@@ -1010,7 +1002,7 @@ mod tests {
             symbols: vec![],
             references: vec![],
             imports: vec![],
-            chunks: vec![chunk_a, chunk_b, chunk_c],
+            chunks: vec![chunk_a.clone(), chunk_b, chunk_c.clone()],
             parse_error: None,
         };
         // Should succeed despite duplicate IDs
@@ -1046,5 +1038,15 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
             .unwrap();
         assert_eq!(total, 2);
+        // Persisted duplicate fields must match the original chunk
+        let (persisted_start, persisted_hash): (i64, String) = conn
+            .query_row(
+                "SELECT start_byte, content_hash FROM chunks WHERE id=?1",
+                params![dup_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(persisted_start as usize, chunk_a.start_byte);
+        assert_eq!(persisted_hash, chunk_a.content_hash);
     }
 }


### PR DESCRIPTION
## **User description**
Large vendor JS (django admin static, nestjs) can produce duplicate chunk IDs for same file, causing UNIQUE constraint failed: chunks.id and ever-growing DB (161→347→639MB). Dedup like symbols before upsert, add regression test dedup_chunk_ids_before_upsert. Verified: cargo fmt --check PASS, clippy PASS, test PASS (with --test-threads=2), release build PASS. Minimal production fix, no bench/cli changes.


___

## **CodeAnt-AI Description**
Prevent duplicate chunk IDs from breaking file indexing

### What Changed
- File indexing now keeps one record for each chunk ID before saving chunks
- Files containing duplicate chunk IDs no longer fail with a database uniqueness error
- Added coverage confirming duplicate chunks are removed while unique chunks remain

### Impact
`✅ Fewer indexing failures for large vendor files`
`✅ Stable chunk database size during repeated indexing`
`✅ Preserved unique chunks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
