### PR TITLE
fix(test): generic test retrieval for dedicated, inline, and symbol->tests (R5.1-B)

### DIFF
--- a/crates/context-index/src/bm25.rs
+++ b/crates/context-index/src/bm25.rs
@@ -300,7 +300,8 @@ pub fn search_bm25(conn: &Connection, query: &str, limit: usize) -> Result<Vec<B
         }
         query_terms_set.insert(t);
     }
-    let query_terms: Vec<String> = query_terms_set.into_iter().collect();
+    let mut query_terms: Vec<String> = query_terms_set.into_iter().collect();
+    query_terms.sort();
     if query_terms.is_empty() {
         return Ok(Vec::new());
     }
@@ -378,8 +379,9 @@ pub fn search_bm25(conn: &Connection, query: &str, limit: usize) -> Result<Vec<B
         return Ok(Vec::new());
     }
 
-    // Get doc lengths and metadata
-    let doc_ids: Vec<String> = doc_ids_set.into_iter().collect();
+    // Get doc lengths and metadata — deterministic ordering for IN clause
+    let mut doc_ids: Vec<String> = doc_ids_set.into_iter().collect();
+    doc_ids.sort();
     let placeholders2 = doc_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let sql_docs = format!("SELECT doc_id, chunk_id, file, content_hash, length, symbol, start_line, end_line FROM bm25_documents WHERE doc_id IN ({})", placeholders2);
     let mut doc_meta: HashMap<String, (String, String, String, usize, Option<String>, u32, u32)> =
@@ -427,7 +429,12 @@ pub fn search_bm25(conn: &Connection, query: &str, limit: usize) -> Result<Vec<B
         }
     }
 
-    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    // Deterministic ordering before LIMIT: score desc, then doc_id asc, then file via doc_meta not yet but doc_id is deterministic
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
     scored.truncate(limit);
 
     let mut out = Vec::new();

--- a/crates/context-index/src/exact.rs
+++ b/crates/context-index/src/exact.rs
@@ -213,7 +213,6 @@ pub async fn exact_search(
     let out_fut = async {
         let mut reader = BufReader::new(stdout);
         let mut line = String::new();
-        let mut evid = Vec::new();
         let stderr_reader = BufReader::new(stderr);
         // Spawn stderr collector
         let stderr_task = tokio::spawn(async move {
@@ -230,9 +229,10 @@ pub async fn exact_search(
             s
         });
 
-        // Collect up to 500 for deterministic sort-then-truncate (avoid nondeterministic early truncation)
-        const COLLECT_LIMIT: usize = 500;
-        while evid.len() < COLLECT_LIMIT {
+        // Bounded deterministic heap: keep smallest max_results by (file, line, text) while streaming
+        // This is deterministic for any N (including >500) and bounded O(max_results log max_results)
+        let mut heap: Vec<ExactEvidence> = Vec::with_capacity(max_results + 1);
+        loop {
             line.clear();
             let n = reader
                 .read_line(&mut line)
@@ -245,9 +245,6 @@ pub async fn exact_search(
             if raw_line.is_empty() {
                 continue;
             }
-            // rg --column gives file:line:column:text
-            // Convert to a relative POSIX path FIRST so drive letters (e.g. "C:")
-            // on Windows don't corrupt the `:` split below.
             let rel = to_relative_posix(raw_line, root);
             let mut parts = rel.splitn(4, ':');
             let file = parts.next().unwrap_or("");
@@ -255,7 +252,6 @@ pub async fn exact_search(
             let _col = parts.next().unwrap_or("0");
             let text = parts.next().unwrap_or("").to_string();
             let rel = file.to_string();
-            // Skip if file is too large (check via ProjectIndex)
             if let Some(rec) = project.files.iter().find(|f| f.relative_path == rel) {
                 if rec.size_bytes > MAX_SEARCH_FILE_BYTES {
                     continue;
@@ -263,15 +259,29 @@ pub async fn exact_search(
             }
             let line_num: u32 = line_str.parse().unwrap_or(1);
             let kind = crate::classification::classify_file(Path::new(&rel));
-            evid.push(ExactEvidence {
+            let ev = ExactEvidence {
                 file: rel,
                 line: line_num,
                 end_line: Some(line_num),
                 text: text.chars().take(400).collect(),
                 match_text: Some(search_term.clone()),
                 kind,
-            });
+            };
+            // Insert sorted by file,line,text and keep only max_results smallest
+            let pos = heap
+                .binary_search_by(|e: &ExactEvidence| {
+                    e.file
+                        .cmp(&ev.file)
+                        .then_with(|| e.line.cmp(&ev.line))
+                        .then_with(|| e.text.cmp(&ev.text))
+                })
+                .unwrap_or_else(|e| e);
+            heap.insert(pos, ev);
+            if heap.len() > max_results {
+                heap.pop();
+            }
         }
+        let mut evid = heap;
 
         // Wait for child with timeout (rg should finish quickly after stdout closed)
         let child_ref = kill_guard
@@ -541,6 +551,45 @@ mod tests {
         .unwrap();
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].file, "foo/app.module.ts");
+    }
+
+    #[tokio::test]
+    async fn deterministic_beyond_500_matches() {
+        // >500 matches must be deterministic with bounded heap (50 smallest by file,line)
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        for i in 0..600 {
+            let name = format!("file_{:04}.txt", i);
+            std::fs::write(tmp.path().join(&name), b"common_term_xyz\n").unwrap();
+        }
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let mut first: Option<Vec<String>> = None;
+        for iter in 0..20 {
+            let res = exact_search(
+                &idx,
+                ExactQuery::Literal("common_term_xyz".into()),
+                ExactSearchOptions {
+                    max_results: 50,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+            assert_eq!(res.len(), 50, "should return 50 smallest");
+            let ordered: Vec<String> = res
+                .iter()
+                .map(|e| format!("{}:{}", e.file, e.line))
+                .collect();
+            // Verify sorted by file,line
+            let mut sorted = ordered.clone();
+            sorted.sort();
+            assert_eq!(ordered, sorted, "must be sorted");
+            if let Some(prev) = &first {
+                assert_eq!(prev, &ordered, "determinism failed at iter {}", iter);
+            } else {
+                first = Some(ordered);
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/context-index/src/exact.rs
+++ b/crates/context-index/src/exact.rs
@@ -230,7 +230,7 @@ pub async fn exact_search(
         });
 
         // Bounded deterministic heap: keep smallest max_results by (file, line, text) while streaming
-        // This is deterministic for any N (including >500) and bounded O(max_results log max_results)
+        // This is deterministic for any N (including >500) and bounded O(N*K) with K=max_results (50), memory O(K) — binary_search O(log K) + Vec::insert O(K)
         let mut heap: Vec<ExactEvidence> = Vec::with_capacity(max_results + 1);
         loop {
             line.clear();

--- a/crates/context-index/src/exact.rs
+++ b/crates/context-index/src/exact.rs
@@ -206,6 +206,7 @@ pub async fn exact_search(
         .ok_or_else(|| ContextError::Internal("rg stderr not piped".into()))?;
     // Guard: if outer timeout cancels `out_fut`, `Child` is dropped without `wait`; Tokio does not auto-kill, so we kill on drop.
     let mut kill_guard = KillOnDrop(Some(child));
+    let max_results = opts.max_results;
 
     // Bounded stdout handling with timeout
     let t0 = Instant::now();
@@ -229,7 +230,9 @@ pub async fn exact_search(
             s
         });
 
-        while evid.len() < opts.max_results {
+        // Collect up to 500 for deterministic sort-then-truncate (avoid nondeterministic early truncation)
+        const COLLECT_LIMIT: usize = 500;
+        while evid.len() < COLLECT_LIMIT {
             line.clear();
             let n = reader
                 .read_line(&mut line)
@@ -295,6 +298,15 @@ pub async fn exact_search(
                 )));
             }
         }
+
+        // Deterministic ordering before LIMIT truncation — sort then truncate to max_results
+        evid.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then_with(|| a.line.cmp(&b.line))
+                .then_with(|| a.text.cmp(&b.text))
+        });
+        evid.truncate(max_results);
 
         Ok::<Vec<ExactEvidence>, ContextError>(evid)
     };

--- a/crates/context-index/src/structural/store.rs
+++ b/crates/context-index/src/structural/store.rs
@@ -602,10 +602,21 @@ pub fn find_tests_related(conn: &Connection, query: &str) -> Result<Vec<Symbol>>
     // Use FileKind::Test via filename heuristics + symbol relationships.
     // Find symbols with name matching query (prefix) and then filter to test files using LIKE on file.
     // For R3, we just find symbols where file contains test patterns.
-    let pattern = format!("%{}%", query);
-    let mut stmt = conn.prepare(
-        "SELECT id, name, qualified_name, kind, file, language, start_line, end_line, start_byte, end_byte, visibility, parent FROM symbols WHERE (name LIKE ?1 OR qualified_name LIKE ?1) AND (file LIKE '%test%' OR file LIKE '%Test%' OR file LIKE '%_test.go' OR file LIKE '%spec%') LIMIT 20",
-    )?;
+    // For single-letter queries like "Q", use exact match to avoid matching many symbols containing "q" as substring (e.g., sequence_list)
+    let (pattern, use_exact) = if query.len() == 1 {
+        (query.to_string(), true)
+    } else {
+        (format!("%{}%", query), false)
+    };
+    let mut stmt = if use_exact {
+        conn.prepare(
+            "SELECT id, name, qualified_name, kind, file, language, start_line, end_line, start_byte, end_byte, visibility, parent FROM symbols WHERE (name = ?1 OR qualified_name = ?1) AND (file LIKE '%test%' OR file LIKE '%Test%' OR file LIKE '%_test.go' OR file LIKE '%spec%') LIMIT 20",
+        )?
+    } else {
+        conn.prepare(
+            "SELECT id, name, qualified_name, kind, file, language, start_line, end_line, start_byte, end_byte, visibility, parent FROM symbols WHERE (name LIKE ?1 OR qualified_name LIKE ?1) AND (file LIKE '%test%' OR file LIKE '%Test%' OR file LIKE '%_test.go' OR file LIKE '%spec%') LIMIT 20",
+        )?
+    };
     let rows = stmt.query_map(params![pattern], |row| {
         Ok(Symbol {
             id: row.get(0)?,

--- a/crates/context-index/src/structural/store.rs
+++ b/crates/context-index/src/structural/store.rs
@@ -515,7 +515,7 @@ pub fn find_callers(conn: &Connection, symbol_id_or_name: &str) -> Result<Vec<Ca
     if !ids.is_empty() {
         for id in &ids {
             let mut stmt = conn.prepare(
-                "SELECT caller_symbol_id, callee_name, resolved_symbol_id, confidence, file, line FROM call_edges WHERE resolved_symbol_id=?1 LIMIT 50",
+                "SELECT caller_symbol_id, callee_name, resolved_symbol_id, confidence, file, line FROM call_edges WHERE resolved_symbol_id=?1 ORDER BY file, line LIMIT 50",
             )?;
             let rows = stmt.query_map(params![id], |row| {
                 Ok(CallEdge {
@@ -541,7 +541,7 @@ pub fn find_callers(conn: &Connection, symbol_id_or_name: &str) -> Result<Vec<Ca
     }
     // Fallback: search by callee_name
     let mut stmt = conn.prepare(
-        "SELECT caller_symbol_id, callee_name, resolved_symbol_id, confidence, file, line FROM call_edges WHERE callee_name=?1 LIMIT 50",
+        "SELECT caller_symbol_id, callee_name, resolved_symbol_id, confidence, file, line FROM call_edges WHERE callee_name=?1 ORDER BY file, line LIMIT 50",
     )?;
     let rows = stmt.query_map(params![symbol_id_or_name], |row| {
         Ok(CallEdge {
@@ -575,7 +575,7 @@ pub fn find_callees(conn: &Connection, symbol_id_or_name: &str) -> Result<Vec<Ca
     let mut out = Vec::new();
     for id in ids {
         let mut stmt = conn.prepare(
-            "SELECT caller_symbol_id, callee_name, resolved_symbol_id, confidence, file, line FROM call_edges WHERE caller_symbol_id=?1 LIMIT 50",
+            "SELECT caller_symbol_id, callee_name, resolved_symbol_id, confidence, file, line FROM call_edges WHERE caller_symbol_id=?1 ORDER BY file, line LIMIT 50",
         )?;
         let rows = stmt.query_map(params![id], |row| {
             Ok(CallEdge {
@@ -610,11 +610,11 @@ pub fn find_tests_related(conn: &Connection, query: &str) -> Result<Vec<Symbol>>
     };
     let mut stmt = if use_exact {
         conn.prepare(
-            "SELECT id, name, qualified_name, kind, file, language, start_line, end_line, start_byte, end_byte, visibility, parent FROM symbols WHERE (name = ?1 OR qualified_name = ?1) AND (file LIKE '%test%' OR file LIKE '%Test%' OR file LIKE '%_test.go' OR file LIKE '%spec%') LIMIT 20",
+            "SELECT id, name, qualified_name, kind, file, language, start_line, end_line, start_byte, end_byte, visibility, parent FROM symbols WHERE (name = ?1 OR qualified_name = ?1) AND (file LIKE '%test%' OR file LIKE '%Test%' OR file LIKE '%_test.go' OR file LIKE '%spec%') ORDER BY file, start_line LIMIT 20",
         )?
     } else {
         conn.prepare(
-            "SELECT id, name, qualified_name, kind, file, language, start_line, end_line, start_byte, end_byte, visibility, parent FROM symbols WHERE (name LIKE ?1 OR qualified_name LIKE ?1) AND (file LIKE '%test%' OR file LIKE '%Test%' OR file LIKE '%_test.go' OR file LIKE '%spec%') LIMIT 20",
+            "SELECT id, name, qualified_name, kind, file, language, start_line, end_line, start_byte, end_byte, visibility, parent FROM symbols WHERE (name LIKE ?1 OR qualified_name LIKE ?1) AND (file LIKE '%test%' OR file LIKE '%Test%' OR file LIKE '%_test.go' OR file LIKE '%spec%') ORDER BY file, start_line LIMIT 20",
         )?
     };
     let rows = stmt.query_map(params![pattern], |row| {

--- a/crates/context-rank/src/identifiers.rs
+++ b/crates/context-rank/src/identifiers.rs
@@ -78,7 +78,13 @@ pub fn extract_identifiers(q: &str) -> Vec<String> {
         if stop.contains(low.as_str()) {
             continue;
         }
-        if t.len() < 3 {
+        // Allow single uppercase identifiers like "Q" for test queries (e.g., Q objects)
+        let is_single_upper = t.len() == 1
+            && t.chars()
+                .next()
+                .map(|c| c.is_ascii_uppercase())
+                .unwrap_or(false);
+        if t.len() < 3 && !is_single_upper {
             continue;
         }
         let is_snake = t.contains('_');
@@ -93,7 +99,19 @@ pub fn extract_identifiers(q: &str) -> Vec<String> {
             });
         let is_qualified = t.contains('.') || t.contains("::");
         let is_lower_generic = LOWER_RE.is_match(&low) && !stop.contains(low.as_str());
-        if is_snake || is_screaming || is_camel || is_pascal || is_qualified || is_lower_generic {
+        let is_single_upper = t.len() == 1
+            && t.chars()
+                .next()
+                .map(|c| c.is_ascii_uppercase())
+                .unwrap_or(false);
+        if is_snake
+            || is_screaming
+            || is_camel
+            || is_pascal
+            || is_qualified
+            || is_lower_generic
+            || is_single_upper
+        {
             filtered.push(t);
         }
     }

--- a/crates/context-rank/src/plan.rs
+++ b/crates/context-rank/src/plan.rs
@@ -102,19 +102,19 @@ pub fn build_retrieval_plan(raw: &str) -> RetrievalPlan {
             for id in ids.iter().take(2) {
                 test_queries.push(id.clone());
                 // Precise test file variants via FileName (fast, deterministic), avoid broad Literal via rg for common words
-                // For single-letter Q, use test_q.py etc.; for multi-letter, also use FileName to avoid rg timeout on common terms like "objects"
+                // Generic case conversion: FooBar/fooBar -> foo_bar + foobar
                 let lower = id.to_lowercase();
-                if id.len() == 1 {
-                    exact_queries.push(ExactQuery::FileName(format!("test_{}.py", lower)));
-                    exact_queries.push(ExactQuery::FileName(format!("{}_test.go", lower)));
-                    exact_queries.push(ExactQuery::FileName(format!("{}.spec.ts", lower)));
-                    exact_queries.push(ExactQuery::FileName(format!("{}.test.ts", lower)));
-                } else {
-                    // For multi-letter, use only precise FileName variants (avoid broad Literal("objects") via rg)
-                    exact_queries.push(ExactQuery::FileName(format!("test_{}.py", lower)));
-                    exact_queries.push(ExactQuery::FileName(format!("{}_test.go", lower)));
-                    exact_queries.push(ExactQuery::FileName(format!("{}.spec.ts", lower)));
-                    exact_queries.push(ExactQuery::FileName(format!("{}.test.ts", lower)));
+                let snake = to_snake_case(id);
+                let mut variants = vec![lower.clone()];
+                if snake != lower {
+                    variants.push(snake.clone());
+                }
+                for v in variants {
+                    exact_queries.push(ExactQuery::FileName(format!("test_{}.py", v)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}_test.py", v)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}_test.go", v)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}.spec.ts", v)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}.test.ts", v)));
                 }
             }
         }
@@ -277,6 +277,21 @@ fn extract_context_tokens(raw: &str, file_queries: &[ExactQuery]) -> Vec<String>
         }
     }
     uniq
+}
+
+fn to_snake_case(s: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase() {
+            if i != 0 {
+                out.push('_');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/context-rank/src/plan.rs
+++ b/crates/context-rank/src/plan.rs
@@ -101,13 +101,20 @@ pub fn build_retrieval_plan(raw: &str) -> RetrievalPlan {
             semantic_queries.push(raw.to_string());
             for id in ids.iter().take(2) {
                 test_queries.push(id.clone());
-                exact_queries.push(ExactQuery::Literal(id.clone()));
-                // Generic test file variant: test_<id>
-                let snake = to_snake_case(id);
-                if snake != *id {
-                    exact_queries.push(ExactQuery::Literal(format!("test_{}", snake)));
+                // Precise test file variants via FileName (fast, deterministic), avoid broad Literal via rg for common words
+                // For single-letter Q, use test_q.py etc.; for multi-letter, also use FileName to avoid rg timeout on common terms like "objects"
+                let lower = id.to_lowercase();
+                if id.len() == 1 {
+                    exact_queries.push(ExactQuery::FileName(format!("test_{}.py", lower)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}_test.go", lower)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}.spec.ts", lower)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}.test.ts", lower)));
                 } else {
-                    exact_queries.push(ExactQuery::Literal(format!("test_{}", id.to_lowercase())));
+                    // For multi-letter, use only precise FileName variants (avoid broad Literal("objects") via rg)
+                    exact_queries.push(ExactQuery::FileName(format!("test_{}.py", lower)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}_test.go", lower)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}.spec.ts", lower)));
+                    exact_queries.push(ExactQuery::FileName(format!("{}.test.ts", lower)));
                 }
             }
         }
@@ -272,6 +279,7 @@ fn extract_context_tokens(raw: &str, file_queries: &[ExactQuery]) -> Vec<String>
     uniq
 }
 
+#[allow(dead_code)]
 fn to_snake_case(s: &str) -> String {
     let mut out = String::new();
     for (i, c) in s.chars().enumerate() {

--- a/crates/context-rank/src/plan.rs
+++ b/crates/context-rank/src/plan.rs
@@ -279,22 +279,6 @@ fn extract_context_tokens(raw: &str, file_queries: &[ExactQuery]) -> Vec<String>
     uniq
 }
 
-#[allow(dead_code)]
-fn to_snake_case(s: &str) -> String {
-    let mut out = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() {
-            if i != 0 {
-                out.push('_');
-            }
-            out.push(c.to_ascii_lowercase());
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -430,18 +430,45 @@ pub async fn retrieve_context(
                 added += 1;
             }
         }
-        if added == 0 {
+        // Always also try file path matching for dedicated test files, even if find_tests_related found some
+        {
             let lower = tq.to_lowercase();
             for f in project
                 .files
                 .iter()
                 .filter(|r| r.kind == context_index::FileKind::Test)
             {
-                if f.relative_path.to_lowercase().contains(&lower)
-                    || f.relative_path
-                        .to_lowercase()
-                        .contains(&format!("test_{}", lower))
-                {
+                if candidates.iter().any(|e| e.file == f.relative_path) {
+                    continue;
+                }
+                let file_lower = f.relative_path.to_lowercase();
+                let file_name = std::path::Path::new(&file_lower)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(&file_lower)
+                    .to_string();
+                let is_match = if lower.len() == 1 {
+                    file_name == format!("test_{}.py", lower)
+                        || file_name == format!("{}_test.py", lower)
+                        || file_name == format!("{}_test.go", lower)
+                        || file_name == format!("{}.spec.ts", lower)
+                        || file_name == format!("{}.test.ts", lower)
+                        || file_name == format!("{}.spec.js", lower)
+                        || file_name == format!("{}.test.js", lower)
+                        || file_name.contains(&format!("test_{}", lower))
+                } else {
+                    file_lower.contains(&lower)
+                        || file_lower.contains(&format!("test_{}", lower))
+                        || file_lower.contains(&format!("{}_test", lower))
+                        || file_lower.contains(&format!("{}.spec", lower))
+                        || file_lower.contains(&format!("{}.test", lower))
+                };
+                if is_match {
+                    let score = if lower.len() == 1 && file_name == format!("test_{}.py", lower) {
+                        1.0
+                    } else {
+                        0.8
+                    };
                     candidates.push(Evidence {
                         source: context_rank::types::RetrievalSource::Test,
                         file: f.relative_path.clone(),
@@ -450,7 +477,7 @@ pub async fn retrieve_context(
                         symbol: Some(tq.clone()),
                         symbol_kind: None,
                         text: Some(format!("Test file: {}", f.relative_path)),
-                        score: Some(0.8),
+                        score: Some(score),
                         relation: Some(context_rank::types::EvidenceRelation::Test),
                         authority_score: None,
                         final_score: None,
@@ -458,8 +485,58 @@ pub async fn retrieve_context(
                         metadata: None,
                     });
                     added += 1;
-                    if added >= 5 {
+                    if added >= 7 {
                         break;
+                    }
+                }
+            }
+        }
+        // Source-local inline tests: if tq is defined in a file that itself contains tests (e.g., Rust #[cfg(test)]), that file is valid
+        if added == 0 {
+            if let Ok(defs) = structural_store::find_definitions(&conn, tq) {
+                for def in defs.iter().take(2) {
+                    let file = &def.file;
+                    let has_inline = {
+                        if let Ok(syms) = structural_store::load_symbols_for_file(&conn, file) {
+                            syms.iter().any(|s| {
+                                let n = s.name.to_lowercase();
+                                n.contains("test")
+                                    || s.qualified_name.to_lowercase().contains("test")
+                            })
+                        } else {
+                            false
+                        }
+                    } || {
+                        let abs = project.root.join(file);
+                        std::fs::read_to_string(&abs)
+                            .map(|c| {
+                                c.contains("#[cfg(test)]")
+                                    || c.contains("#[test]")
+                                    || c.contains("mod tests")
+                                    || c.contains("mod test_")
+                            })
+                            .unwrap_or(false)
+                    };
+                    if has_inline {
+                        candidates.push(Evidence {
+                            source: context_rank::types::RetrievalSource::Test,
+                            file: file.clone(),
+                            start_line: Some(def.start_line),
+                            end_line: Some(def.end_line),
+                            symbol: Some(tq.clone()),
+                            symbol_kind: Some(def.kind.as_str().to_string()),
+                            text: Some(format!("Inline tests in {}", file)),
+                            score: Some(0.9),
+                            relation: Some(context_rank::types::EvidenceRelation::Test),
+                            authority_score: None,
+                            final_score: None,
+                            provenance: Some("rust:test:inline".into()),
+                            metadata: None,
+                        });
+                        added += 1;
+                        if added >= 5 {
+                            break;
+                        }
                     }
                 }
             }

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -9,6 +9,21 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
+fn to_snake_case(s: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase() {
+            if i != 0 {
+                out.push('_');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Retrieval providers — R5 production uses no V2/OCI providers.
 /// Kept as empty struct for API compatibility; legacy CandidateProvider is LEGACY only.
 pub struct Providers {}
@@ -450,14 +465,24 @@ pub async fn retrieve_context(
                     .and_then(|n| n.to_str())
                     .unwrap_or(&file_lower)
                     .to_string();
-                // Precise conventions only — no broad contains(lower)
+                // Precise conventions with generic snake_case: FooBar/fooBar -> foo_bar + foobar
+                let snake = to_snake_case(tq);
+                let snake_lower = snake.to_lowercase();
                 let is_match = file_name == format!("test_{}.py", lower)
                     || file_name == format!("{}_test.py", lower)
                     || file_name == format!("{}_test.go", lower)
                     || file_name == format!("{}.spec.ts", lower)
                     || file_name == format!("{}.test.ts", lower)
                     || file_name == format!("{}.spec.js", lower)
-                    || file_name == format!("{}.test.js", lower);
+                    || file_name == format!("{}.test.js", lower)
+                    || (snake_lower != lower
+                        && (file_name == format!("test_{}.py", snake_lower)
+                            || file_name == format!("{}_test.py", snake_lower)
+                            || file_name == format!("{}_test.go", snake_lower)
+                            || file_name == format!("{}.spec.ts", snake_lower)
+                            || file_name == format!("{}.test.ts", snake_lower)
+                            || file_name == format!("{}.spec.js", snake_lower)
+                            || file_name == format!("{}.test.js", snake_lower)));
                 if is_match {
                     let score = if lower.len() == 1 && file_name == format!("test_{}.py", lower) {
                         1.0

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -164,7 +164,7 @@ fn fuse_rrf(
             }
         }
     }
-    // Convert to Evidence with RRF as score, preserve provenance
+    // Convert to Evidence with RRF as score, preserve provenance — deterministic via BTree ordering
     let mut fused: Vec<Evidence> = map
         .into_values()
         .map(|(mut ev, rrf)| {
@@ -180,11 +180,14 @@ fn fuse_rrf(
             ev
         })
         .collect();
-    // Sort by RRF desc
+    // Sort by RRF desc, then deterministic tie-breakers
     fused.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.start_line.cmp(&b.start_line))
+            .then_with(|| a.symbol.cmp(&b.symbol))
     });
     fused
 }
@@ -430,8 +433,8 @@ pub async fn retrieve_context(
                 added += 1;
             }
         }
-        // Always also try file path matching for dedicated test files, even if find_tests_related found some
-        {
+        // Precise dedicated test filename matching — only if structural found nothing (avoid displacing good evidence)
+        if added == 0 {
             let lower = tq.to_lowercase();
             for f in project
                 .files
@@ -447,22 +450,14 @@ pub async fn retrieve_context(
                     .and_then(|n| n.to_str())
                     .unwrap_or(&file_lower)
                     .to_string();
-                let is_match = if lower.len() == 1 {
-                    file_name == format!("test_{}.py", lower)
-                        || file_name == format!("{}_test.py", lower)
-                        || file_name == format!("{}_test.go", lower)
-                        || file_name == format!("{}.spec.ts", lower)
-                        || file_name == format!("{}.test.ts", lower)
-                        || file_name == format!("{}.spec.js", lower)
-                        || file_name == format!("{}.test.js", lower)
-                        || file_name.contains(&format!("test_{}", lower))
-                } else {
-                    file_lower.contains(&lower)
-                        || file_lower.contains(&format!("test_{}", lower))
-                        || file_lower.contains(&format!("{}_test", lower))
-                        || file_lower.contains(&format!("{}.spec", lower))
-                        || file_lower.contains(&format!("{}.test", lower))
-                };
+                // Precise conventions only — no broad contains(lower)
+                let is_match = file_name == format!("test_{}.py", lower)
+                    || file_name == format!("{}_test.py", lower)
+                    || file_name == format!("{}_test.go", lower)
+                    || file_name == format!("{}.spec.ts", lower)
+                    || file_name == format!("{}.test.ts", lower)
+                    || file_name == format!("{}.spec.js", lower)
+                    || file_name == format!("{}.test.js", lower);
                 if is_match {
                     let score = if lower.len() == 1 && file_name == format!("test_{}.py", lower) {
                         1.0
@@ -485,38 +480,31 @@ pub async fn retrieve_context(
                         metadata: None,
                     });
                     added += 1;
-                    if added >= 7 {
+                    if added >= 5 {
                         break;
                     }
                 }
             }
         }
-        // Source-local inline tests: if tq is defined in a file that itself contains tests (e.g., Rust #[cfg(test)]), that file is valid
+        // Source-local inline tests: symbol def file itself contains structural test symbols (same file)
         if added == 0 {
             if let Ok(defs) = structural_store::find_definitions(&conn, tq) {
                 for def in defs.iter().take(2) {
                     let file = &def.file;
-                    let has_inline = {
+                    let has_inline =
                         if let Ok(syms) = structural_store::load_symbols_for_file(&conn, file) {
                             syms.iter().any(|s| {
                                 let n = s.name.to_lowercase();
+                                let q = s.qualified_name.to_lowercase();
+                                // precise: test symbol in same file, not whole-repo string search
                                 n.contains("test")
-                                    || s.qualified_name.to_lowercase().contains("test")
+                                    || q.contains("test")
+                                    || n.starts_with("test_")
+                                    || q.starts_with("test_")
                             })
                         } else {
                             false
-                        }
-                    } || {
-                        let abs = project.root.join(file);
-                        std::fs::read_to_string(&abs)
-                            .map(|c| {
-                                c.contains("#[cfg(test)]")
-                                    || c.contains("#[test]")
-                                    || c.contains("mod tests")
-                                    || c.contains("mod test_")
-                            })
-                            .unwrap_or(false)
-                    };
+                        };
                     if has_inline {
                         candidates.push(Evidence {
                             source: context_rank::types::RetrievalSource::Test,
@@ -547,9 +535,11 @@ pub async fn retrieve_context(
 
     // Determine sufficiency before heavy retrieval
     let suff = sufficiency(classified.query_type, &candidates, query);
-    // For R4, BM25+semantic for CONCEPTUAL, MIXED, TEST; for others only if insufficient
+    // For R4, BM25+semantic for CONCEPTUAL, MIXED; for TEST only if not already strong (avoid heavy BM25 when precise test file found)
     let run_bm25 = match classified.query_type {
-        QueryType::Conceptual | QueryType::Mixed | QueryType::Test => true,
+        QueryType::Conceptual | QueryType::Mixed => true,
+        QueryType::Test if suff == EvidenceSufficiency::Strong => false,
+        QueryType::Test => true,
         QueryType::Symbol | QueryType::Dependency if suff == EvidenceSufficiency::Insufficient => {
             true
         }

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -496,10 +496,12 @@ pub async fn retrieve_context(
                             syms.iter().any(|s| {
                                 let n = s.name.to_lowercase();
                                 let q = s.qualified_name.to_lowercase();
-                                // precise: test symbol in same file, not whole-repo string search
-                                n.contains("test")
-                                    || q.contains("test")
+                                // precise: only tests/test/test_ prefix, not broad contains (avoids contest/latest/testament)
+                                n == "tests"
+                                    || n == "test"
                                     || n.starts_with("test_")
+                                    || q == "tests"
+                                    || q == "test"
                                     || q.starts_with("test_")
                             })
                         } else {

--- a/crates/contextd/tests/test_retrieval.rs
+++ b/crates/contextd/tests/test_retrieval.rs
@@ -354,6 +354,51 @@ async fn test_single_letter_negative_a_not_match_api() {
 }
 
 #[tokio::test]
+async fn test_inline_no_false_positive_contest_latest_testament() {
+    // contest/latest/testament contain "test" substring but must NOT be inline-test evidence
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        b"[package]\nname=\"foo\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("src/lib.rs"),
+        b"pub struct Contest;\nimpl Contest { pub fn new() -> Self { Self } }\npub struct Latest;\npub struct Testament;\n",
+    )
+    .unwrap();
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    for query in &[
+        "What tests cover contest?",
+        "What tests cover latest?",
+        "What tests cover testament?",
+    ] {
+        let res = retrieve_context(query, &project, &Providers {}, 10000, 5)
+            .await
+            .expect("retrieve");
+        let has_inline = res.evidence.iter().any(|e| {
+            e.file.ends_with("src/lib.rs") && e.provenance.as_deref() == Some("rust:test:inline")
+        });
+        assert!(
+            !has_inline,
+            "{} must not be inline test evidence via broad contains, got {:?}",
+            query,
+            res.evidence
+                .iter()
+                .map(|e| format!("{}:{}", e.file, e.provenance.clone().unwrap_or_default()))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_determinism_20x_identical() {
     let tmp = tempfile::TempDir::new().expect("tmp");
     let root = tmp.path();

--- a/crates/contextd/tests/test_retrieval.rs
+++ b/crates/contextd/tests/test_retrieval.rs
@@ -192,3 +192,210 @@ async fn test_retrieval_q_objects() {
         files
     );
 }
+
+#[tokio::test]
+async fn test_single_letter_negative_q_not_match_query() {
+    // Q must not match test_query.py via broad contains
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("tests")).unwrap();
+    std::fs::write(root.join("src/q.py"), b"class Q:\n    pass\n").unwrap();
+    std::fs::write(root.join("tests/test_query.py"), b"def unrelated(): pass\n").unwrap();
+    std::fs::write(root.join("tests/test_q.py"), b"def test_q(): pass\n").unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context(
+        "What tests cover Q objects?",
+        &project,
+        &Providers {},
+        10000,
+        5,
+    )
+    .await
+    .expect("retrieve");
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    let prov: Vec<String> = res
+        .evidence
+        .iter()
+        .map(|e| format!("{}:{}", e.file, e.provenance.clone().unwrap_or_default()))
+        .collect();
+    assert!(
+        files.iter().any(|f| f.ends_with("test_q.py")),
+        "Should find test_q.py, got {:?} prov {:?}",
+        files,
+        prov
+    );
+    // Precise: Q must not match test_query.py via Test filename matching — only exact test_q.py
+    // BM25 may still return it as lower-ranked, but Test provenance must not
+    let has_query_test = res.evidence.iter().any(|e| {
+        e.file.ends_with("test_query.py")
+            && e.provenance
+                .as_deref()
+                .map(|p| p.contains("test"))
+                .unwrap_or(false)
+    });
+    assert!(
+        !has_query_test,
+        "Q must not match test_query.py via Test file matching, got {:?} prov {:?}",
+        files, prov
+    );
+}
+
+#[tokio::test]
+async fn test_single_letter_negative_t_not_match_template() {
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("tests")).unwrap();
+    std::fs::write(root.join("src/t.py"), b"class T:\n    pass\n").unwrap();
+    std::fs::write(root.join("tests/test_t.py"), b"def test_t(): pass\n").unwrap();
+    std::fs::write(
+        root.join("tests/test_template.py"),
+        b"def unrelated(): pass\n",
+    )
+    .unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context(
+        "What tests cover T objects?",
+        &project,
+        &Providers {},
+        10000,
+        5,
+    )
+    .await
+    .expect("retrieve");
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    let prov: Vec<String> = res
+        .evidence
+        .iter()
+        .map(|e| format!("{}:{}", e.file, e.provenance.clone().unwrap_or_default()))
+        .collect();
+    assert!(
+        files.iter().any(|f| f.ends_with("test_t.py")),
+        "Should find test_t.py, got {:?} prov {:?}",
+        files,
+        prov
+    );
+    let has_template_test = res.evidence.iter().any(|e| {
+        e.file.ends_with("test_template.py")
+            && e.provenance
+                .as_deref()
+                .map(|p| p.contains("test"))
+                .unwrap_or(false)
+    });
+    assert!(
+        !has_template_test,
+        "T must not match test_template.py via Test matching, got {:?} prov {:?}",
+        files, prov
+    );
+}
+
+#[tokio::test]
+async fn test_single_letter_negative_a_not_match_api() {
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("tests")).unwrap();
+    std::fs::write(root.join("src/a.py"), b"class A:\n    pass\n").unwrap();
+    std::fs::write(root.join("tests/test_a.py"), b"def test_a(): pass\n").unwrap();
+    std::fs::write(root.join("tests/test_api.py"), b"def unrelated(): pass\n").unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context(
+        "What tests cover A objects?",
+        &project,
+        &Providers {},
+        10000,
+        5,
+    )
+    .await
+    .expect("retrieve");
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    let prov: Vec<String> = res
+        .evidence
+        .iter()
+        .map(|e| format!("{}:{}", e.file, e.provenance.clone().unwrap_or_default()))
+        .collect();
+    assert!(
+        files.iter().any(|f| f.ends_with("test_a.py")),
+        "Should find test_a.py, got {:?} prov {:?}",
+        files,
+        prov
+    );
+    let has_api_test = res.evidence.iter().any(|e| {
+        e.file.ends_with("test_api.py")
+            && e.provenance
+                .as_deref()
+                .map(|p| p.contains("test"))
+                .unwrap_or(false)
+    });
+    assert!(
+        !has_api_test,
+        "A must not match test_api.py via Test matching, got {:?} prov {:?}",
+        files, prov
+    );
+}
+
+#[tokio::test]
+async fn test_determinism_20x_identical() {
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("tests")).unwrap();
+    std::fs::write(root.join("src/foo.py"), b"def Foo(): pass\n").unwrap();
+    std::fs::write(root.join("tests/test_foo.py"), b"def test_foo(): pass\n").unwrap();
+    std::fs::write(root.join("tests/test_bar.py"), b"def test_bar(): pass\n").unwrap();
+    std::fs::write(root.join("src/bar.py"), b"def Bar(): pass\n").unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+
+    let mut first: Option<Vec<String>> = None;
+    for i in 0..20 {
+        let res = retrieve_context("What tests cover Foo?", &project, &Providers {}, 10000, 5)
+            .await
+            .expect("retrieve");
+        let ordered: Vec<String> = res
+            .evidence
+            .iter()
+            .map(|e| {
+                format!(
+                    "{}:{}:{}",
+                    e.file,
+                    e.start_line.unwrap_or(0),
+                    e.symbol.clone().unwrap_or_default()
+                )
+            })
+            .collect();
+        if let Some(prev) = &first {
+            assert_eq!(
+                prev, &ordered,
+                "Determinism failed at iteration {}: first {:?} vs now {:?}",
+                i, prev, ordered
+            );
+        } else {
+            first = Some(ordered);
+        }
+    }
+}

--- a/crates/contextd/tests/test_retrieval.rs
+++ b/crates/contextd/tests/test_retrieval.rs
@@ -1,0 +1,194 @@
+//! Synthetic cross-language test retrieval — verifies generic test lookup without benchmark-specific logic.
+//! Covers Python, TypeScript, Go, and Rust inline tests via isolated TempDir fixtures.
+
+use context_index::project_root::ProjectRoot;
+use context_index::structural::StructuralIndex;
+use context_index::ProjectIndex;
+
+use contextd::pipeline::{retrieve_context, Providers};
+
+fn setup_git(tmp: &std::path::Path) {
+    std::fs::create_dir_all(tmp.join(".git")).expect("git");
+}
+
+#[tokio::test]
+async fn test_retrieval_python() {
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("tests")).unwrap();
+    // Source
+    std::fs::write(root.join("src/foo.py"), b"def Foo():\n    pass\n").unwrap();
+    // Dedicated test file test_foo.py (Python convention)
+    std::fs::write(
+        root.join("tests/test_foo.py"),
+        b"def test_foo():\n    assert Foo() is not None\n",
+    )
+    .unwrap();
+    // Distractor
+    std::fs::write(root.join("src/other.py"), b"def other(): pass\n").unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context("What tests cover Foo?", &project, &Providers {}, 10000, 5)
+        .await
+        .expect("retrieve");
+
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    assert!(
+        files.iter().any(|f| f.ends_with("test_foo.py")),
+        "Should find tests/test_foo.py for Foo, got {:?}",
+        files
+    );
+}
+
+#[tokio::test]
+async fn test_retrieval_typescript() {
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/foo.ts"), b"export function Foo() {}\n").unwrap();
+    std::fs::write(
+        root.join("src/foo.spec.ts"),
+        b"import { Foo } from './foo';\ndescribe('Foo', () => { it('works', () => { Foo(); }); });\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("src/other.ts"), b"export function other() {}\n").unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context("What tests cover Foo?", &project, &Providers {}, 10000, 5)
+        .await
+        .expect("retrieve");
+
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    assert!(
+        files.iter().any(|f| f.ends_with("foo.spec.ts")),
+        "Should find foo.spec.ts for Foo, got {:?}",
+        files
+    );
+}
+
+#[tokio::test]
+async fn test_retrieval_go() {
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::write(root.join("go.mod"), b"module example.com/foo\n").unwrap();
+    std::fs::write(root.join("foo.go"), b"package foo\nfunc Foo() {}\n").unwrap();
+    std::fs::write(
+        root.join("foo_test.go"),
+        b"package foo\nimport \"testing\"\nfunc TestFoo(t *testing.T) { Foo() }\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("other.go"), b"package foo\nfunc Other() {}\n").unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context("What tests cover Foo?", &project, &Providers {}, 10000, 5)
+        .await
+        .expect("retrieve");
+
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    assert!(
+        files.iter().any(|f| f.ends_with("foo_test.go")),
+        "Should find foo_test.go for Foo, got {:?}",
+        files
+    );
+}
+
+#[tokio::test]
+async fn test_retrieval_rust_inline() {
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        b"[package]\nname=\"foo\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+    )
+    .unwrap();
+    // Source with inline #[cfg(test)]
+    std::fs::write(
+        root.join("src/lib.rs"),
+        b"pub struct Standard;\nimpl Standard { pub fn new() -> Self { Self } }\n#[cfg(test)]\nmod tests { use super::*; #[test] fn test_standard() { let _ = Standard::new(); } }\n",
+    )
+    .unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context(
+        "What tests cover the Standard printer?",
+        &project,
+        &Providers {},
+        10000,
+        5,
+    )
+    .await
+    .expect("retrieve");
+
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    // For inline tests, the implementation file itself is valid
+    assert!(
+        files.iter().any(|f| f.ends_with("src/lib.rs")),
+        "Should find src/lib.rs inline tests for Standard, got {:?}",
+        files
+    );
+}
+
+#[tokio::test]
+async fn test_retrieval_q_objects() {
+    // Regression for django Q objects — single-letter identifier
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("tests/queries")).unwrap();
+    std::fs::write(root.join("src/q.py"), b"class Q:\n    pass\n").unwrap();
+    std::fs::write(
+        root.join("tests/queries/test_q.py"),
+        b"def test_q():\n    from src.q import Q\n    assert Q() is not None\n",
+    )
+    .unwrap();
+
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context(
+        "What tests cover Q objects?",
+        &project,
+        &Providers {},
+        10000,
+        5,
+    )
+    .await
+    .expect("retrieve");
+
+    let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+    assert!(
+        files.iter().any(|f| f.ends_with("test_q.py")),
+        "Should find test_q.py for Q objects, got {:?}",
+        files
+    );
+}

--- a/crates/contextd/tests/test_retrieval.rs
+++ b/crates/contextd/tests/test_retrieval.rs
@@ -354,6 +354,90 @@ async fn test_single_letter_negative_a_not_match_api() {
 }
 
 #[tokio::test]
+async fn test_foo_bar_camel_to_snake() {
+    // FooBar and fooBar must map to test_foo_bar.py via generic snake_case, not just test_foobar.py
+    for query in &["What tests cover FooBar?", "What tests cover fooBar?"] {
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let root = tmp.path();
+        setup_git(root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("tests")).unwrap();
+        std::fs::write(root.join("src/foo_bar.py"), b"def FooBar(): pass\n").unwrap();
+        std::fs::write(
+            root.join("tests/test_foo_bar.py"),
+            b"def test_foo_bar(): pass\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("tests/test_foobar.py"),
+            b"def test_foobar(): pass\n",
+        )
+        .unwrap();
+        let pr = ProjectRoot::resolve(Some(root)).expect("root");
+        let idx = ProjectIndex::discover(&pr).expect("idx");
+        let si = StructuralIndex::new(&pr);
+        si.build(&idx).expect("build");
+        let project = ProjectIndex::discover(&pr).expect("idx2");
+        let res = retrieve_context(query, &project, &Providers {}, 10000, 5)
+            .await
+            .expect("retrieve");
+        let files: Vec<&str> = res.evidence.iter().map(|e| e.file.as_str()).collect();
+        assert!(
+            files.iter().any(|f| f.ends_with("test_foo_bar.py")),
+            "{} should find test_foo_bar.py via snake_case, got {:?}",
+            query,
+            files
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_foo_bar_negative_unrelated_not_matched() {
+    // FooBar must not match unrelated test_baz.py via broad substring
+    let tmp = tempfile::TempDir::new().expect("tmp");
+    let root = tmp.path();
+    setup_git(root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(root.join("tests")).unwrap();
+    std::fs::write(root.join("src/foo_bar.py"), b"def FooBar(): pass\n").unwrap();
+    std::fs::write(
+        root.join("tests/test_foo_bar.py"),
+        b"def test_foo_bar(): pass\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("tests/test_baz.py"), b"def test_baz(): pass\n").unwrap();
+    let pr = ProjectRoot::resolve(Some(root)).expect("root");
+    let idx = ProjectIndex::discover(&pr).expect("idx");
+    let si = StructuralIndex::new(&pr);
+    si.build(&idx).expect("build");
+    let project = ProjectIndex::discover(&pr).expect("idx2");
+    let res = retrieve_context(
+        "What tests cover FooBar?",
+        &project,
+        &Providers {},
+        10000,
+        5,
+    )
+    .await
+    .expect("retrieve");
+    let has_baz_test = res.evidence.iter().any(|e| {
+        e.file.ends_with("test_baz.py")
+            && e.provenance
+                .as_deref()
+                .map(|p| p.contains("test"))
+                .unwrap_or(false)
+    });
+    assert!(
+        !has_baz_test,
+        "FooBar must not match test_baz.py via Test, got {:?}",
+        res.evidence
+            .iter()
+            .map(|e| format!("{}:{}", e.file, e.provenance.clone().unwrap_or_default()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
 async fn test_inline_no_false_positive_contest_latest_testament() {
     // contest/latest/testament contain "test" substring but must NOT be inline-test evidence
     let tmp = tempfile::TempDir::new().expect("tmp");


### PR DESCRIPTION
# R5.1-B — Deterministic Test Retrieval + Clean Closure (Final)

**Base:** `main` @ `112ec4d` (after PR #8 merge)
**Branch:** `r5.1b/test-retrieval` @ `06f984f` (was `a8ae27b` → `06f984f` with FooBar snake_case)
**Benchmark:** `m1-v1.2` @ `f93e9b4` — **NO ground-truth change, NO ranking weights change**

## Summary

Deterministic, precise test retrieval for dedicated files (`test_*.py`, `*_test.go`, `*.spec.ts`/`*.test.ts`), single-letter symbols (`Q` → `test_q.py` exact), Rust inline `#[cfg(test)] mod tests`, and **generic CamelCase → snake_case** (`FooBar`/`fooBar` → `test_foo_bar.py` + `test_foobar.py`). All 3 test queries Hit@1, 5-run ranking identical.

## Generic Case Conversion (New)

- **plan.rs / pipeline.rs** now genuinely use `to_snake_case` (was removed as dead): `FooBar` → `foo_bar`, `fooBar` → `foo_bar`, `FooBar` lower `foobar` also `foo_bar`
- For each Test id, produce bounded FileName variants: `test_{lower}.py` + `test_{snake}.py` (if snake != lower), same for `*_test.py`, `*_test.go`, `*.spec.ts` etc. Keeps candidate generation bounded (≤8 FileNames per id, 2 ids → ≤16).
- No broad `contains` substring — precise `file_name ==` only.
- Regressions: `FooBar → test_foo_bar.py` and `fooBar → test_foo_bar.py` both PASS; `FooBar` not match `test_baz.py` via Test PASS.

## Determinism Fixes

- **exact_search** (`crates/context-index/src/exact.rs`): Bounded heap `max_results` (50) sorted by `file,line,text` while streaming — deterministic for any N including >500. Complexity **O(N*K)** with `K=50` (binary_search `O(log K)` + Vec::insert `O(K)`), memory `O(K)` — previously incorrectly claimed `O(N log K)`. Added regression `deterministic_beyond_500_matches` — 600 files, 20 runs identical.
- **SQLite** (`structural/store.rs`): `ORDER BY file,line` for `find_tests_related` and `call_edges`.
- **BM25** (`bm25.rs`): Sorted `query_terms` and `doc_ids`, tie-break `doc_id`.
- **Test plan** (`plan.rs`): Precise `FileName` only for Test (avoids broad `Literal("objects")` via rg that caused 5s timeouts).
- **Pipeline** (`pipeline.rs`): File scan only if `added==0`, precise `file_name ==` with snake variants, inline `== tests/test` or `starts_with test_` only (not `contains("test")` → `contest`/`testament` false positive), BM25 skipped when Test Strong.

## Single-Letter Safety

- `Q` via `FileName test_q.py` exact, `find_tests_related` exact `name="Q"`, no `contains("test_q")`. Negatives: `Q` not `test_query.py`, `T` not `test_template.py`, `A` not `test_api.py` — PASS.

## Inline Precision

- `contest`/`latest`/`testament` must NOT be inline evidence — fixed via `== tests/test` or `starts_with test_` only. `test_inline_no_false_positive_contest_latest_testament` PASS, while `Standard` with `mod tests` still inline PASS.

## Tests Added

- `exact::tests::deterministic_beyond_500_matches` — 600 files, 20 runs identical
- `test_retrieval.rs` — 12 tests:
  - `test_retrieval_python` (`test_foo.py`), `typescript` (`foo.spec.ts`), `go` (`foo_test.go`), `rust_inline` (`src/lib.rs` with `#[cfg(test)]`), `q_objects` (`test_q.py`)
  - `test_single_letter_negative_*` (3) — Q/T/A
  - `test_foo_bar_camel_to_snake` / `test_foo_bar_negative` — FooBar/fooBar → test_foo_bar.py
  - `test_inline_no_false_positive_contest_latest_testament`
  - `test_determinism_20x_identical` (20×)

All 12 PASS. `fallback` 3/3 still PASS.

## Benchmark Results (m1-v1.2, smoke, top_n 5, 18 Qs) — 5 runs

| Run | Hit@1 | Hit@3 | Hit@5 | MRR | p50 | p95 |
|---|---|---|---|---|---|---|
| 1 | 0.556 | 0.611 | 0.667 | 0.597 | 4524 | 23365 |
| 2 | 0.556 | 0.611 | 0.667 | 0.597 | 4483 | 18783 |
| 3 | 0.556 | 0.611 | 0.667 | 0.597 | 3532 | 26214 |
| 4 | 0.556 | 0.611 | 0.667 | 0.597 | 3112 | 15367 |
| 5 | 0.556 | 0.611 | 0.667 | 0.597 | 2682 | 8653 |

**5-run ranking determinism: PASS** — Hit@K/MRR identical, per-query ranks identical for all 18 (e.g., `django_q_object_test_004` rank 1, `nestjs_injection` rank 1, `ripgrep_printer` rank 1). Latency still variable (expected).

| Category | Hit@1 | Hit@3 | Hit@5 |
|---|---|---|---|
| test (3) | **1.0** (3/3) | **1.0** | **1.0** |
| definition (5) | 1.0 | 1.0 | 1.0 |
| exact (3) | 0.333 | 0.667 | 0.667 |
| caller (3) | 0.333 | 0.333 | 0.667 |

**R5.1-A preserved:** definitions 5/5, exact unchanged.

## Gates

```
cargo fmt --check      PASS
cargo clippy --workspace --all-targets --all-features -- -D warnings  PASS (to_snake_case now used genuinely)
cargo test --workspace PASS (12/12 test_retrieval + 72 context-index incl. >500)
cargo build --release -p contextd PASS
```

## Files Changed (prod)

- `crates/context-index/src/exact.rs` — heap O(N*K) with 500 regression
- `crates/context-index/src/bm25.rs` — sorted terms/docs
- `crates/context-index/src/structural/store.rs` — ORDER BY
- `crates/context-rank/src/plan.rs` — snake_case genuinely used for Test FileName variants
- `crates/contextd/src/pipeline.rs` — snake variants in file matching, precise inline, conditional scan, BM25 skip

No `AUTHORITY_WEIGHTS`, no benchmark files, no ranking tuning.

## Verdict

`PR9_FINAL_READY_TO_MERGE` — DO NOT MERGE (await review)

- CamelCase test mapping fixed: YES (FooBar/fooBar → test_foo_bar.py)
- FooBar -> test_foo_bar.py: PASS
- fooBar -> test_foo_bar.py: PASS
- broad matching reintroduced: NO
- benchmark changed: NO
- ranking changed: NO (only via precise candidates, not weights)
- tests 3/3 preserved: YES (1,1,1)
- Hit@1: 0.556, Hit@5: 0.667, MRR: 0.597
