### PR TITLE
R5.1-C production semantic indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ name = "contextd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "context-core",
  "context-index",

--- a/crates/context-index/src/embed.rs
+++ b/crates/context-index/src/embed.rs
@@ -48,14 +48,13 @@ pub trait Embedder: Send + Sync {
 /// Deterministic fake embedder for tests and fallback.
 /// Produces fixed vectors via blake3 hash, normalized.
 /// Not for quality benchmarking, but for incremental reuse and unit tests.
-#[cfg(test)]
+// ponytail: simple test helper, kept unconditional for cross-crate tests
 pub struct FakeEmbedder {
     model: String,
     dim: usize,
     version: String,
 }
 
-#[cfg(test)]
 impl FakeEmbedder {
     pub fn new(model: &str, dim: usize) -> Self {
         Self {
@@ -83,7 +82,6 @@ impl FakeEmbedder {
     }
 }
 
-#[cfg(test)]
 #[async_trait]
 impl Embedder for FakeEmbedder {
     fn model_id(&self) -> &str {
@@ -138,6 +136,102 @@ impl Embedder for SlowTestEmbedder {
         tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
         self.inner.embed_documents(texts).await
     }
+}
+
+/// Canonical configured model helpers — single source for indexing/query/status.
+/// CONTEXTD_EMBED_MODEL drives all; DO NOT hardcode elsewhere.
+pub fn configured_model_name() -> String {
+    std::env::var("CONTEXTD_EMBED_MODEL").unwrap_or_else(|_| "all-minilm".to_string())
+}
+
+pub fn configured_fingerprint() -> ModelFingerprint {
+    let model = configured_model_name();
+    match model.as_str() {
+        "all-minilm" => ModelFingerprint {
+            model_id: "all-minilm".to_string(),
+            version: "ollama-all-minilm-v1".to_string(),
+            dimension: 384,
+        },
+        "nomic-embed-text" => ModelFingerprint {
+            model_id: "nomic-embed-text".to_string(),
+            version: "ollama-nomic-embed-text-v1".to_string(),
+            dimension: 768,
+        },
+        other => ModelFingerprint {
+            model_id: other.to_string(),
+            version: format!("ollama-{}-v1", other),
+            dimension: 768,
+        },
+    }
+}
+
+pub fn configured_embedder() -> OllamaEmbedder {
+    let fp = configured_fingerprint();
+    OllamaEmbedder::with_model(&fp.model_id, fp.dimension)
+}
+
+/// Returns true if Ollama daemon reachable AND configured model is listed in /api/tags.
+/// If daemon exists but model absent, returns false (truthful unavailable).
+pub async fn is_configured_model_available() -> bool {
+    // honor semantic disable
+    if let Ok(v) = std::env::var("CONTEXTD_SEMANTIC_ENABLED") {
+        if v == "0" || v.to_lowercase() == "false" {
+            return false;
+        }
+    }
+    let fp = configured_fingerprint();
+    is_model_available(&fp.model_id).await
+}
+
+pub async fn is_model_available(model_id: &str) -> bool {
+    let ollama_host =
+        std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string());
+    let url = format!("{}/api/tags", ollama_host.trim_end_matches('/'));
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let resp = match tokio::time::timeout(
+        std::time::Duration::from_millis(800),
+        client.get(&url).send(),
+    )
+    .await
+    {
+        Ok(Ok(r)) if r.status().is_success() => r,
+        _ => return false,
+    };
+    // Parse tags JSON: {"models": [{"name":"all-minilm:latest", ...}]}
+    if let Ok(json) = resp.json::<serde_json::Value>().await {
+        if let Some(models) = json.get("models").and_then(|v| v.as_array()) {
+            for m in models {
+                if let Some(name) = m.get("name").and_then(|v| v.as_str()) {
+                    // name may contain tag suffix like ":latest" or digest
+                    let base = name.split(':').next().unwrap_or(name);
+                    if base == model_id
+                        || name == model_id
+                        || name.starts_with(&format!("{}:", model_id))
+                    {
+                        return true;
+                    }
+                }
+                if let Some(model) = m.get("model").and_then(|v| v.as_str()) {
+                    let base = model.split(':').next().unwrap_or(model);
+                    if base == model_id {
+                        return true;
+                    }
+                }
+            }
+            // If models array empty, but daemon reachable, we still consider model unavailable
+            return false;
+        }
+        // Some Ollama versions return empty or different shape but daemon reachable — if we expected a specific model, treat as unavailable
+        // However for backward compat: if tags endpoint succeeds but parsing fails, assume daemon reachable but can't verify model -> require model
+        return false;
+    }
+    false
 }
 
 /// Nomic via Ollama (historical baseline).

--- a/crates/context-index/src/structural/mod.rs
+++ b/crates/context-index/src/structural/mod.rs
@@ -39,6 +39,14 @@ pub struct IndexStats {
     pub structural_generation: u64,
 }
 
+/// Result of structural reconcile exposing generic delta without semantic knowledge.
+#[derive(Debug, Clone, Default)]
+pub struct StructuralBuildOutcome {
+    pub stats: IndexStats,
+    pub changed_files: Vec<String>,
+    pub deleted_files: Vec<String>,
+}
+
 /// Structural indexer — owns incremental build logic.
 /// Uses hash-based reuse: unchanged hash → skip parse.
 /// Persistent store: SQLite at .context/index/structural.db, worktree-safe.
@@ -70,6 +78,11 @@ impl StructuralIndex {
     /// ProjectIndex respects .opencodeignore which hides crates for V2. Structural needs Rust.
     /// R4: incremental graph — no global rebuild on normal one-file change.
     pub fn build(&self, project: &ProjectIndex) -> Result<IndexStats> {
+        self.build_with_delta(project).map(|o| o.stats)
+    }
+
+    /// Build with generic delta (changed/deleted paths). Ollama-free, deterministic.
+    pub fn build_with_delta(&self, project: &ProjectIndex) -> Result<StructuralBuildOutcome> {
         let t0 = Instant::now();
         let mut conn = store::open_db(&self.root)?;
         let structural_files = collect_structural_files(&self.root, project);
@@ -215,7 +228,14 @@ impl StructuralIndex {
         }
 
         stats.elapsed_ms = t0.elapsed().as_millis();
-        Ok(stats)
+        // deterministic ordering for callers (semantic sync) and tests
+        changed_files.sort();
+        stale_files.sort();
+        Ok(StructuralBuildOutcome {
+            stats,
+            changed_files,
+            deleted_files: stale_files,
+        })
     }
 
     /// Single-file incremental update for watcher path.

--- a/crates/context-index/src/vector.rs
+++ b/crates/context-index/src/vector.rs
@@ -232,6 +232,16 @@ pub async fn sync_missing_vectors_for_root(
     root: &std::path::Path,
     embedder: &dyn Embedder,
 ) -> Result<(usize, usize, usize, usize)> {
+    sync_missing_vectors_for_root_with_batch_size(conn, root, embedder, 256).await
+}
+
+/// Testable helper with explicit batch_size (production 256, tests use 8).
+pub async fn sync_missing_vectors_for_root_with_batch_size(
+    conn: &mut Connection,
+    root: &std::path::Path,
+    embedder: &dyn Embedder,
+    batch_size: usize,
+) -> Result<(usize, usize, usize, usize)> {
     ensure_vector_schema(conn)?;
     let fp = embedder.fingerprint();
     let _ = delete_stale_vectors(conn, &fp)?;
@@ -272,7 +282,7 @@ pub async fn sync_missing_vectors_for_root(
     let mut hashes: Vec<String> = by_hash.keys().cloned().collect();
     hashes.sort();
     // Prepare texts batching
-    let batch_size = 256usize; // ponytail: larger batch for Ollama throughput, still bounded
+    let batch_size = batch_size;
     let mut total_embedded = 0usize;
     let mut total_calls = 0usize;
     let mut file_cache: std::collections::HashMap<String, String> =
@@ -320,6 +330,69 @@ pub async fn sync_missing_vectors_for_root(
     // GC orphaned after sync (clean stale from deleted files)
     let _ = gc_orphaned_vectors(conn, &fp);
     Ok((reused, total_embedded, total_calls, total_embedded))
+}
+
+/// Load chunks for a file (for incremental sync).
+pub fn load_chunks_for_file(conn: &Connection, file: &str) -> Result<Vec<Chunk>> {
+    ensure_vector_schema(conn)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, file, language, start_line, end_line, start_byte, end_byte, parent_symbol, content_hash, text_size_bytes FROM chunks WHERE file=?1 ORDER BY start_line, start_byte",
+    )?;
+    let rows = stmt.query_map(params![file], |row| {
+        Ok(Chunk {
+            id: row.get(0)?,
+            file: row.get(1)?,
+            language: crate::structural::language::Language::from_str(&row.get::<_, String>(2)?),
+            start_line: row.get::<_, i64>(3)? as u32,
+            end_line: row.get::<_, i64>(4)? as u32,
+            start_byte: row.get::<_, i64>(5)? as usize,
+            end_byte: row.get::<_, i64>(6)? as usize,
+            parent_symbol: row.get(7)?,
+            content_hash: row.get(8)?,
+            text_size_bytes: row.get::<_, i64>(9)? as usize,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// Incremental sync for changed files only (fast, uses changed_files delta).
+/// Returns (reused, embedded, calls).
+pub async fn sync_changed_files_vectors(
+    conn: &mut Connection,
+    root: &std::path::Path,
+    changed_files: &[String],
+    embedder: &dyn Embedder,
+) -> Result<(usize, usize, usize)> {
+    if changed_files.is_empty() {
+        return Ok((0, 0, 0));
+    }
+    let fp = embedder.fingerprint();
+    // delete stale for this fingerprint first
+    let _ = delete_stale_vectors(conn, &fp)?;
+    let mut total_reused = 0usize;
+    let mut total_embedded = 0usize;
+    let mut total_calls = 0usize;
+    for file in changed_files {
+        let chunks = match load_chunks_for_file(conn, file) {
+            Ok(c) if !c.is_empty() => c,
+            _ => continue,
+        };
+        let abs = root.join(file);
+        let content = std::fs::read_to_string(&abs).unwrap_or_default();
+        let (reused, embedded) = sync_vectors_for_file(conn, file, &chunks, &content, embedder).await?;
+        total_reused += reused;
+        total_embedded += embedded;
+        if embedded > 0 {
+            total_calls += 1;
+        }
+    }
+    // GC orphaned after incremental (handles deleted files if caller also calls GC)
+    let _ = gc_orphaned_vectors(conn, &fp);
+    Ok((total_reused, total_embedded, total_calls))
 }
 
 /// Conservative orphan GC: delete vectors whose content_hash is not referenced by any current chunk
@@ -1141,8 +1214,9 @@ mod tests {
         let tmp = tempfile::TempDir::new()?;
         let root = tmp.path().to_path_buf();
         std::fs::create_dir_all(root.join(".git"))?;
-        // create many files to exceed batch size 64 (2 batches)
-        for i in 0..70 {
+        // Use small batch size 8 to test batch-independent partial failure
+        // 16 docs -> 2 batches of 8
+        for i in 0..16 {
             let content = format!("def foo_{}():\n    x = {}\n", i, i);
             std::fs::write(root.join(format!("f{}.py", i)), content.as_bytes())?;
         }
@@ -1153,32 +1227,38 @@ mod tests {
         let mut conn = crate::structural::store::open_db(&root)?;
         let calls = Arc::new(AtomicUsize::new(0));
         let ff = FailingFake::new("j-model", 8, 2, calls.clone());
-        let res = crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &ff).await;
+        let res = crate::vector::sync_missing_vectors_for_root_with_batch_size(
+            &mut conn, &root, &ff, 8,
+        )
+        .await;
         assert!(res.is_err(), "second batch should fail");
-        // first batch 64 should have persisted
+        // first batch 8 should have persisted
         let fp = ff.fingerprint();
         let cnt = count_vectors(&conn, &fp)? as usize;
         assert_eq!(
-            cnt, 64,
+            cnt, 8,
             "first batch persisted despite second failure, got {}",
             cnt
         );
         let missing = missing_vector_count(&conn, &fp)?;
-        assert_eq!(missing, 6, "remaining missing should be 6, got {}", missing);
+        assert_eq!(missing, 8, "remaining missing should be 8, got {}", missing);
         assert!(!is_semantic_ready(&conn, &fp, true)?);
-        // retry with good embedder should embed only remaining 6
+        // retry with good embedder should embed only remaining 8
         let calls2 = Arc::new(AtomicUsize::new(0));
         let docs2 = Arc::new(AtomicUsize::new(0));
         let cf = CountingFake::new("j-model", 8, calls2.clone(), docs2.clone());
         let (reused, embedded, calls_n, _docs) =
-            crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf).await?;
+            crate::vector::sync_missing_vectors_for_root_with_batch_size(
+                &mut conn, &root, &cf, 8,
+            )
+            .await?;
         assert_eq!(
-            embedded, 6,
-            "retry should embed only missing 6, got {}",
+            embedded, 8,
+            "retry should embed only missing 8, got {}",
             embedded
         );
         assert_eq!(calls_n, 1);
-        assert_eq!(reused, 64);
+        assert_eq!(reused, 8);
         assert_eq!(missing_vector_count(&conn, &fp)?, 0);
         assert!(is_semantic_ready(&conn, &fp, true)?);
         Ok(())

--- a/crates/context-index/src/vector.rs
+++ b/crates/context-index/src/vector.rs
@@ -107,10 +107,15 @@ pub fn get_vector(
 ) -> Result<Option<Vec<f32>>> {
     ensure_vector_schema(conn)?;
     let mut stmt = conn.prepare(
-        "SELECT vector, dimension FROM vectors WHERE content_hash=?1 AND model_id=?2 AND version=?3",
+        "SELECT vector, dimension FROM vectors WHERE content_hash=?1 AND model_id=?2 AND version=?3 AND dimension=?4",
     )?;
     let row = stmt.query_row(
-        params![content_hash, fingerprint.model_id, fingerprint.version],
+        params![
+            content_hash,
+            fingerprint.model_id,
+            fingerprint.version,
+            fingerprint.dimension as i64
+        ],
         |r| {
             let blob: Vec<u8> = r.get(0)?;
             let dim: i64 = r.get(1)?;
@@ -127,8 +132,12 @@ pub fn get_vector(
 pub fn count_vectors(conn: &Connection, fingerprint: &ModelFingerprint) -> Result<i64> {
     ensure_vector_schema(conn)?;
     Ok(conn.query_row(
-        "SELECT COUNT(*) FROM vectors WHERE model_id=?1 AND version=?2",
-        params![fingerprint.model_id, fingerprint.version],
+        "SELECT COUNT(*) FROM vectors WHERE model_id=?1 AND version=?2 AND dimension=?3",
+        params![
+            fingerprint.model_id,
+            fingerprint.version,
+            fingerprint.dimension as i64
+        ],
         |r| r.get(0),
     )?)
 }
@@ -137,12 +146,14 @@ pub fn count_vectors(conn: &Connection, fingerprint: &ModelFingerprint) -> Resul
 /// Old vectors must not be silently reused.
 pub fn invalidate_stale_model(conn: &Connection, fingerprint: &ModelFingerprint) -> Result<usize> {
     ensure_vector_schema(conn)?;
-    // If dimension or version changed, old entries have different version/dimension, but we keep them? Spec says old vectors must not be reused when model id/version/dim changes.
-    // Our get_vector already keys on version, so old version won't be returned. But to avoid disk bloat, we could delete old versions.
-    // For now, just report count of stale (different version) — caller can delete if needed.
+    // Count stale: same model but version or dimension differs (must not be reused)
     let cnt: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM vectors WHERE model_id=?1 AND version!=?2",
-        params![fingerprint.model_id, fingerprint.version],
+        "SELECT COUNT(*) FROM vectors WHERE model_id=?1 AND (version!=?2 OR dimension!=?3)",
+        params![
+            fingerprint.model_id,
+            fingerprint.version,
+            fingerprint.dimension as i64
+        ],
         |r| r.get(0),
     )?;
     Ok(cnt as usize)
@@ -151,9 +162,164 @@ pub fn invalidate_stale_model(conn: &Connection, fingerprint: &ModelFingerprint)
 pub fn delete_stale_vectors(conn: &Connection, fingerprint: &ModelFingerprint) -> Result<usize> {
     ensure_vector_schema(conn)?;
     Ok(conn.execute(
-        "DELETE FROM vectors WHERE model_id=?1 AND version!=?2",
-        params![fingerprint.model_id, fingerprint.version],
+        "DELETE FROM vectors WHERE model_id=?1 AND (version!=?2 OR dimension!=?3)",
+        params![
+            fingerprint.model_id,
+            fingerprint.version,
+            fingerprint.dimension as i64
+        ],
     )?)
+}
+
+/// Eligible unique chunk hashes (distinct content_hash from current chunks).
+pub fn eligible_chunk_count(conn: &Connection) -> Result<usize> {
+    ensure_vector_schema(conn)?;
+    let cnt: i64 = conn.query_row("SELECT COUNT(DISTINCT content_hash) FROM chunks", [], |r| {
+        r.get(0)
+    })?;
+    Ok(cnt as usize)
+}
+
+/// Vector count for fingerprint (distinct content_hash, primary key ensures distinct).
+pub fn vector_count_for(conn: &Connection, fingerprint: &ModelFingerprint) -> Result<usize> {
+    Ok(count_vectors(conn, fingerprint)? as usize)
+}
+
+/// Missing vectors for fingerprint: eligible distinct - present distinct (via LEFT JOIN for accuracy).
+pub fn missing_vector_count(conn: &Connection, fingerprint: &ModelFingerprint) -> Result<usize> {
+    ensure_vector_schema(conn)?;
+    let cnt: i64 = conn.query_row(
+        "SELECT COUNT(DISTINCT c.content_hash) FROM chunks c LEFT JOIN vectors v ON v.content_hash=c.content_hash AND v.model_id=?1 AND v.version=?2 AND v.dimension=?3 WHERE v.content_hash IS NULL",
+        params![fingerprint.model_id, fingerprint.version, fingerprint.dimension as i64],
+        |r| r.get(0),
+    )?;
+    Ok(cnt as usize)
+}
+
+/// Stale vector count (same model, version or dimension mismatch).
+pub fn stale_vector_count(conn: &Connection, fingerprint: &ModelFingerprint) -> Result<usize> {
+    invalidate_stale_model(conn, fingerprint)
+}
+
+/// Whether semantic index is ready: backend available && missing==0 && eligible>0
+pub fn is_semantic_ready(
+    conn: &Connection,
+    fingerprint: &ModelFingerprint,
+    backend_available: bool,
+) -> Result<bool> {
+    if !backend_available {
+        return Ok(false);
+    }
+    let eligible = eligible_chunk_count(conn)?;
+    if eligible == 0 {
+        return Ok(false);
+    }
+    let missing = missing_vector_count(conn, fingerprint)?;
+    Ok(missing == 0)
+}
+
+/// Legacy wrapper — prefers CWD; use sync_missing_vectors_for_root if root known.
+pub async fn sync_missing_vectors(
+    conn: &mut Connection,
+    embedder: &dyn Embedder,
+) -> Result<(usize, usize, usize, usize)> {
+    sync_missing_vectors_for_root(conn, std::path::Path::new("."), embedder).await
+}
+
+/// Root-aware variant for production (preferred): caller provides root for file reads.
+pub async fn sync_missing_vectors_for_root(
+    conn: &mut Connection,
+    root: &std::path::Path,
+    embedder: &dyn Embedder,
+) -> Result<(usize, usize, usize, usize)> {
+    ensure_vector_schema(conn)?;
+    let fp = embedder.fingerprint();
+    let _ = delete_stale_vectors(conn, &fp)?;
+
+    let by_hash: std::collections::HashMap<String, (String, usize, usize, Option<String>)> = {
+        let mut stmt = conn.prepare(
+            "SELECT c.content_hash, c.file, c.start_byte, c.end_byte, c.parent_symbol FROM chunks c LEFT JOIN vectors v ON v.content_hash=c.content_hash AND v.model_id=?1 AND v.version=?2 AND v.dimension=?3 WHERE v.content_hash IS NULL ORDER BY c.file, c.start_byte",
+        )?;
+        let rows = stmt.query_map(
+            params![fp.model_id, fp.version, fp.dimension as i64],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)? as usize,
+                    row.get::<_, i64>(3)? as usize,
+                    row.get::<_, Option<String>>(4)?,
+                ))
+            },
+        )?;
+        let mut map: std::collections::HashMap<String, (String, usize, usize, Option<String>)> =
+            std::collections::HashMap::new();
+        for r in rows {
+            let (hash, file, sb, eb, sym) = r?;
+            map.entry(hash).or_insert((file, sb, eb, sym));
+        }
+        map
+    };
+    if by_hash.is_empty() {
+        // eligible distinct count for reused
+        let eligible = eligible_chunk_count(conn)?;
+        return Ok((eligible, 0, 0, 0));
+    }
+    let eligible = eligible_chunk_count(conn)?;
+    let missing_distinct = by_hash.len();
+    let reused = eligible.saturating_sub(missing_distinct);
+
+    let mut hashes: Vec<String> = by_hash.keys().cloned().collect();
+    hashes.sort();
+    // Prepare texts batching
+    let batch_size = 256usize; // ponytail: larger batch for Ollama throughput, still bounded
+    let mut total_embedded = 0usize;
+    let mut total_calls = 0usize;
+    let mut file_cache: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+
+    // Build all missing entries with combined text
+    let mut entries: Vec<(String, String)> = Vec::with_capacity(missing_distinct);
+    for hash in hashes {
+        let (file, sb, eb, sym) = by_hash.get(&hash).unwrap();
+        let content = if let Some(c) = file_cache.get(file) {
+            c.clone()
+        } else {
+            let abs = root.join(file);
+            let c = std::fs::read_to_string(&abs).unwrap_or_default();
+            file_cache.insert(file.clone(), c.clone());
+            c
+        };
+        let bytes = content.as_bytes();
+        let slice = if *sb < bytes.len() && *eb <= bytes.len() {
+            std::str::from_utf8(&bytes[*sb..*eb])
+                .unwrap_or("")
+                .to_string()
+        } else {
+            String::new()
+        };
+        let combined = if let Some(sym) = sym {
+            format!("{} {}\n{}", file, sym, slice)
+        } else {
+            format!("{} {}", file, slice)
+        };
+        entries.push((hash.clone(), combined));
+    }
+
+    // Batch embed with persistence per batch for partial failure handling
+    for chunk in entries.chunks(batch_size) {
+        let texts: Vec<String> = chunk.iter().map(|(_, t)| t.clone()).collect();
+        let hashes_chunk: Vec<String> = chunk.iter().map(|(h, _)| h.clone()).collect();
+        total_calls += 1;
+        let vectors = embedder.embed_documents(&texts).await?;
+        for (hash, vec) in hashes_chunk.into_iter().zip(vectors) {
+            upsert_vector(conn, &hash, &fp, &vec)?;
+            total_embedded += 1;
+        }
+    }
+    // GC orphaned after sync (clean stale from deleted files)
+    let _ = gc_orphaned_vectors(conn, &fp);
+    Ok((reused, total_embedded, total_calls, total_embedded))
 }
 
 /// Conservative orphan GC: delete vectors whose content_hash is not referenced by any current chunk
@@ -162,10 +328,10 @@ pub fn delete_stale_vectors(conn: &Connection, fingerprint: &ModelFingerprint) -
 /// For rename/revert: if content reappears, it will be re-embedded (acceptable for bounded storage).
 pub fn gc_orphaned_vectors(conn: &Connection, fingerprint: &ModelFingerprint) -> Result<usize> {
     ensure_vector_schema(conn)?;
-    // Vectors whose hash not in any current chunk
+    // Vectors whose hash not in any current chunk (scoped to fingerprint exact match)
     Ok(conn.execute(
-        "DELETE FROM vectors WHERE model_id=?1 AND version=?2 AND content_hash NOT IN (SELECT content_hash FROM chunks)",
-        params![fingerprint.model_id, fingerprint.version],
+        "DELETE FROM vectors WHERE model_id=?1 AND version=?2 AND dimension=?3 AND content_hash NOT IN (SELECT content_hash FROM chunks)",
+        params![fingerprint.model_id, fingerprint.version, fingerprint.dimension as i64],
     )?)
 }
 
@@ -240,16 +406,23 @@ pub fn search_brute(
     limit: usize,
 ) -> Result<Vec<VectorCandidate>> {
     ensure_vector_schema(conn)?;
-    // Get all vectors for model
+    // Get all vectors for model (dimension must match)
     let mut stmt = conn.prepare(
-        "SELECT content_hash, vector, dimension FROM vectors WHERE model_id=?1 AND version=?2",
+        "SELECT content_hash, vector, dimension FROM vectors WHERE model_id=?1 AND version=?2 AND dimension=?3",
     )?;
-    let rows = stmt.query_map(params![fingerprint.model_id, fingerprint.version], |row| {
-        let hash: String = row.get(0)?;
-        let blob: Vec<u8> = row.get(1)?;
-        let dim: i64 = row.get(2)?;
-        Ok((hash, blob, dim as usize))
-    })?;
+    let rows = stmt.query_map(
+        params![
+            fingerprint.model_id,
+            fingerprint.version,
+            fingerprint.dimension as i64
+        ],
+        |row| {
+            let hash: String = row.get(0)?;
+            let blob: Vec<u8> = row.get(1)?;
+            let dim: i64 = row.get(2)?;
+            Ok((hash, blob, dim as usize))
+        },
+    )?;
     let mut scored: Vec<(String, f32)> = Vec::new();
     for r in rows {
         let (hash, blob, dim) = r?;
@@ -266,14 +439,19 @@ pub fn search_brute(
         let s = cosine(query_vec, &vec);
         scored.push((hash, s));
     }
-    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    // Deterministic ordering: score desc, hash asc tie-breaker, then after mapping file/line/chunk_id
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
     scored.truncate(limit * 2); // oversample before dedup via chunk mapping
                                 // Map content_hash -> chunk metadata (choose one chunk per hash, or multiple if same content appears elsewhere)
-                                // For now, pick first chunk per hash from chunks table
+                                // For now, pick first chunk per hash from chunks table with deterministic ordering
     let mut out = Vec::new();
     for (hash, score) in scored {
         let mut stmt2 = conn.prepare(
-            "SELECT id, file, start_line, end_line, parent_symbol, content_hash FROM chunks WHERE content_hash=?1 LIMIT 5",
+            "SELECT id, file, start_line, end_line, parent_symbol, content_hash FROM chunks WHERE content_hash=?1 ORDER BY file ASC, start_line ASC, id ASC LIMIT 5",
         )?;
         let chunk_rows = stmt2.query_map(params![hash], |row| {
             Ok((
@@ -304,6 +482,15 @@ pub fn search_brute(
             break;
         }
     }
+    // Final deterministic ordering for equal scores: score desc file asc start_line asc chunk_id asc
+    out.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.start_line.cmp(&b.start_line))
+            .then_with(|| a.chunk_id.cmp(&b.chunk_id))
+    });
     out.truncate(limit);
     Ok(out)
 }
@@ -654,6 +841,414 @@ mod tests {
             "error should mention dimension mismatch"
         );
         assert_eq!(count_vectors(&conn, &fp)?, 0);
+        Ok(())
+    }
+
+    // ---- R5.1-C extended tests ----
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct CountingFake {
+        inner: FakeEmbedder,
+        calls: Arc<AtomicUsize>,
+        docs: Arc<AtomicUsize>,
+    }
+    impl CountingFake {
+        fn new(model: &str, dim: usize, calls: Arc<AtomicUsize>, docs: Arc<AtomicUsize>) -> Self {
+            Self {
+                inner: FakeEmbedder::new(model, dim),
+                calls,
+                docs,
+            }
+        }
+    }
+    #[async_trait::async_trait]
+    impl crate::embed::Embedder for CountingFake {
+        fn model_id(&self) -> &str {
+            self.inner.model_id()
+        }
+        fn dimension(&self) -> usize {
+            self.inner.dimension()
+        }
+        fn version(&self) -> &str {
+            self.inner.version()
+        }
+        async fn embed_query(&self, q: &str) -> Result<Vec<f32>> {
+            self.inner.embed_query(q).await
+        }
+        async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.docs.fetch_add(texts.len(), Ordering::SeqCst);
+            self.inner.embed_documents(texts).await
+        }
+    }
+
+    struct FailingFake {
+        inner: FakeEmbedder,
+        fail_on_call: usize,
+        calls: Arc<AtomicUsize>,
+    }
+    impl FailingFake {
+        fn new(model: &str, dim: usize, fail_on_call: usize, calls: Arc<AtomicUsize>) -> Self {
+            Self {
+                inner: FakeEmbedder::new(model, dim),
+                fail_on_call,
+                calls,
+            }
+        }
+    }
+    #[async_trait::async_trait]
+    impl crate::embed::Embedder for FailingFake {
+        fn model_id(&self) -> &str {
+            self.inner.model_id()
+        }
+        fn dimension(&self) -> usize {
+            self.inner.dimension()
+        }
+        fn version(&self) -> &str {
+            self.inner.version()
+        }
+        async fn embed_query(&self, q: &str) -> Result<Vec<f32>> {
+            self.inner.embed_query(q).await
+        }
+        async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            let cur = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if cur == self.fail_on_call {
+                anyhow::bail!("injected failure on call {}", cur);
+            }
+            self.inner.embed_documents(texts).await
+        }
+    }
+
+    #[tokio::test]
+    async fn r5c_a_initial_and_b_no_change() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git"))?;
+        std::fs::write(root.join("a.py"), b"def foo():\n    pass\n")?;
+        std::fs::write(root.join("b.py"), b"def bar():\n    pass\n")?;
+        let pr = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx = crate::discovery::ProjectIndex::discover(&pr)?;
+        let si = crate::structural::StructuralIndex::for_path(root.clone());
+        let out = si.build_with_delta(&idx)?;
+        assert!(out.changed_files.len() >= 2);
+        let mut conn = crate::structural::store::open_db(&root)?;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let docs = Arc::new(AtomicUsize::new(0));
+        let cf = CountingFake::new("test-model", 8, calls.clone(), docs.clone());
+        let (reused, embedded, calls_n, _docs_n) =
+            crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf).await?;
+        assert!(embedded > 0, "initial should embed");
+        assert_eq!(calls.load(Ordering::SeqCst), calls_n);
+        assert_eq!(eligible_chunk_count(&conn)?, (reused + embedded));
+        // B no-change: second call 0
+        let calls2 = Arc::new(AtomicUsize::new(0));
+        let docs2 = Arc::new(AtomicUsize::new(0));
+        let cf2 = CountingFake::new("test-model", 8, calls2.clone(), docs2.clone());
+        let (reused2, embedded2, calls_n2, _docs_n2) =
+            crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf2).await?;
+        assert_eq!(embedded2, 0, "no-change embedded should be 0");
+        assert_eq!(calls_n2, 0, "no-change calls should be 0");
+        assert_eq!(calls2.load(Ordering::SeqCst), 0);
+        assert_eq!(missing_vector_count(&conn, &cf2.fingerprint())?, 0);
+        assert_eq!(reused2, reused + embedded);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn r5c_c_one_file_change_only_missing() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git"))?;
+        // a.py with two functions -> likely 2 chunks? plus b.py unchanged
+        std::fs::write(
+            root.join("a.py"),
+            b"def foo():\n    x=1\ndef bar():\n    y=2\n",
+        )?;
+        std::fs::write(root.join("b.py"), b"def baz():\n    z=3\n")?;
+        let pr = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx = crate::discovery::ProjectIndex::discover(&pr)?;
+        let si = crate::structural::StructuralIndex::for_path(root.clone());
+        si.build_with_delta(&idx)?;
+        let mut conn = crate::structural::store::open_db(&root)?;
+        let cf = FakeEmbedder::new("c-model", 8);
+        crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf).await?;
+        let before_missing = missing_vector_count(&conn, &cf.fingerprint())?;
+        assert_eq!(before_missing, 0);
+        let eligible_before = eligible_chunk_count(&conn)?;
+        // edit one file: change foo body only
+        std::fs::write(
+            root.join("a.py"),
+            b"def foo():\n    x=999\ndef bar():\n    y=2\n",
+        )?;
+        let pr2 = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx2 = crate::discovery::ProjectIndex::discover(&pr2)?;
+        let out2 = si.build_with_delta(&idx2)?;
+        // Only a.py should be changed
+        assert!(out2.changed_files.contains(&"a.py".to_string()));
+        assert!(!out2.changed_files.contains(&"b.py".to_string()));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let docs = Arc::new(AtomicUsize::new(0));
+        let cf2 = CountingFake::new("c-model", 8, calls.clone(), docs.clone());
+        let (reused, embedded, calls_n, _docs) =
+            crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf2).await?;
+        // Only changed chunk embedded (1), others reused
+        assert_eq!(
+            embedded, 1,
+            "only changed hash should embed, got {}",
+            embedded
+        );
+        assert!(reused >= 1);
+        assert_eq!(calls_n, 1);
+        assert_eq!(docs.load(Ordering::SeqCst), 1);
+        assert_eq!(missing_vector_count(&conn, &cf2.fingerprint())?, 0);
+        let eligible_after = eligible_chunk_count(&conn)?;
+        // eligible may stay same (if chunk count same) but ensure reused+embedded == eligible_after
+        assert_eq!(reused + embedded, eligible_after);
+        assert_eq!(eligible_before, eligible_after);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn r5c_d_delete_orphan_and_e_shared_preserved() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git"))?;
+        // identical chunk content in two files
+        let same = b"def foo():\n    pass\n";
+        std::fs::write(root.join("a.py"), same)?;
+        std::fs::write(root.join("b.py"), same)?;
+        let pr = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx = crate::discovery::ProjectIndex::discover(&pr)?;
+        let si = crate::structural::StructuralIndex::for_path(root.clone());
+        si.build_with_delta(&idx)?;
+        let mut conn = crate::structural::store::open_db(&root)?;
+        let cf = FakeEmbedder::new("d-model", 4);
+        crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf).await?;
+        let cnt_before = count_vectors(&conn, &cf.fingerprint())?;
+        // eligible distinct should be 1 (same chunk hash)
+        assert_eq!(cnt_before, 1);
+        // delete a.py
+        std::fs::remove_file(root.join("a.py"))?;
+        let pr2 = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx2 = crate::discovery::ProjectIndex::discover(&pr2)?;
+        let out = si.build_with_delta(&idx2)?;
+        assert!(out.deleted_files.contains(&"a.py".to_string()));
+        // GC should retain vector because b.py still has same hash
+        let conn2 = crate::structural::store::open_db(&root)?;
+        let _ = crate::vector::gc_orphaned_vectors(&conn2, &cf.fingerprint())?;
+        assert_eq!(
+            count_vectors(&conn2, &cf.fingerprint())?,
+            1,
+            "shared vector should be preserved"
+        );
+        // now delete b.py also
+        std::fs::remove_file(root.join("b.py"))?;
+        let pr3 = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx3 = crate::discovery::ProjectIndex::discover(&pr3)?;
+        let out3 = si.build_with_delta(&idx3)?;
+        assert!(out3.deleted_files.contains(&"b.py".to_string()));
+        let conn3 = crate::structural::store::open_db(&root)?;
+        let deleted = crate::vector::gc_orphaned_vectors(&conn3, &cf.fingerprint())?;
+        assert_eq!(deleted, 1, "orphan should be deleted");
+        assert_eq!(count_vectors(&conn3, &cf.fingerprint())?, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn r5c_f_model_mismatch_not_reused() -> Result<()> {
+        let mut conn = open_in_memory()?;
+        let e1 = FakeEmbedder::new("modelA", 4);
+        let fp1 = e1.fingerprint();
+        let chunk = Chunk {
+            id: "c1".to_string(),
+            file: "a.py".to_string(),
+            language: Language::Python,
+            start_line: 1,
+            end_line: 2,
+            start_byte: 0,
+            end_byte: 3,
+            parent_symbol: None,
+            content_hash: "h1".to_string(),
+            text_size_bytes: 3,
+        };
+        sync_vectors_for_file(&mut conn, "a.py", &[chunk.clone()], "abc", &e1).await?;
+        assert_eq!(count_vectors(&conn, &fp1)?, 1);
+        // Different model B with same hash should be considered missing (not reused)
+        let e2 = FakeEmbedder::new("modelB", 4);
+        let fp2 = e2.fingerprint();
+        assert_eq!(count_vectors(&conn, &fp2)?, 0);
+        assert_eq!(missing_vector_count(&conn, &fp2)?, 0); // no chunks in this in-mem without chunks table? but we inserted via sync? chunks not in chunks table, eligible 0, so missing 0. Instead test via get_vector
+        assert!(
+            get_vector(&conn, "h1", &fp2)?.is_none(),
+            "different model should not reuse"
+        );
+        // version mismatch
+        let fp_v2 = ModelFingerprint {
+            model_id: "modelA".to_string(),
+            version: "v2".to_string(),
+            dimension: 4,
+        };
+        assert!(get_vector(&conn, "h1", &fp_v2)?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn r5c_g_dimension_mismatch_rejected() -> Result<()> {
+        let mut conn = open_in_memory()?;
+        let fp4 = ModelFingerprint {
+            model_id: "test".to_string(),
+            version: "v1".to_string(),
+            dimension: 4,
+        };
+        let fp8 = ModelFingerprint {
+            model_id: "test".to_string(),
+            version: "v1".to_string(),
+            dimension: 8,
+        };
+        // upsert 4-dim vector
+        let vec4 = vec![1.0, 2.0, 3.0, 4.0];
+        upsert_vector(&mut conn, "hash1", &fp4, &vec4)?;
+        assert_eq!(count_vectors(&conn, &fp4)?, 1);
+        assert_eq!(
+            count_vectors(&conn, &fp8)?,
+            0,
+            "dimension mismatch should not count"
+        );
+        assert!(
+            get_vector(&conn, "hash1", &fp8)?.is_none(),
+            "dimension mismatch should not reuse"
+        );
+        // missing should count as missing for fp8 if chunk exists
+        conn.execute(
+            "INSERT OR IGNORE INTO files (path, hash, language) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["a.py", "h", "python"],
+        )?;
+        conn.execute(
+            "INSERT INTO chunks (id, file, language, start_line, end_line, start_byte, end_byte, parent_symbol, content_hash, text_size_bytes) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
+            rusqlite::params!["c1", "a.py", "python", 1, 2, 0, 3, Option::<String>::None, "hash1", 3],
+        )?;
+        // Now eligible 1, missing for fp8 should be 1 (since fp8 has no vector)
+        assert_eq!(missing_vector_count(&conn, &fp8)?, 1);
+        assert_eq!(missing_vector_count(&conn, &fp4)?, 0);
+        // stale should be 1 for fp8 (same model, dimension diff)
+        assert_eq!(stale_vector_count(&conn, &fp8)?, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn r5c_j_partial_failure_and_retry() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git"))?;
+        // create many files to exceed batch size 64 (2 batches)
+        for i in 0..70 {
+            let content = format!("def foo_{}():\n    x = {}\n", i, i);
+            std::fs::write(root.join(format!("f{}.py", i)), content.as_bytes())?;
+        }
+        let pr = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx = crate::discovery::ProjectIndex::discover(&pr)?;
+        let si = crate::structural::StructuralIndex::for_path(root.clone());
+        si.build_with_delta(&idx)?;
+        let mut conn = crate::structural::store::open_db(&root)?;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ff = FailingFake::new("j-model", 8, 2, calls.clone());
+        let res = crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &ff).await;
+        assert!(res.is_err(), "second batch should fail");
+        // first batch 64 should have persisted
+        let fp = ff.fingerprint();
+        let cnt = count_vectors(&conn, &fp)? as usize;
+        assert_eq!(
+            cnt, 64,
+            "first batch persisted despite second failure, got {}",
+            cnt
+        );
+        let missing = missing_vector_count(&conn, &fp)?;
+        assert_eq!(missing, 6, "remaining missing should be 6, got {}", missing);
+        assert!(!is_semantic_ready(&conn, &fp, true)?);
+        // retry with good embedder should embed only remaining 6
+        let calls2 = Arc::new(AtomicUsize::new(0));
+        let docs2 = Arc::new(AtomicUsize::new(0));
+        let cf = CountingFake::new("j-model", 8, calls2.clone(), docs2.clone());
+        let (reused, embedded, calls_n, _docs) =
+            crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf).await?;
+        assert_eq!(
+            embedded, 6,
+            "retry should embed only missing 6, got {}",
+            embedded
+        );
+        assert_eq!(calls_n, 1);
+        assert_eq!(reused, 64);
+        assert_eq!(missing_vector_count(&conn, &fp)?, 0);
+        assert!(is_semantic_ready(&conn, &fp, true)?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn r5c_l_determinism_20x() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git"))?;
+        std::fs::write(
+            root.join("a.py"),
+            b"def alpha():\n    query semantic search test\n",
+        )?;
+        std::fs::write(
+            root.join("b.py"),
+            b"def beta():\n    query semantic search test\n",
+        )?;
+        std::fs::write(root.join("c.py"), b"def gamma():\n    different content\n")?;
+        let pr = crate::project_root::ProjectRoot::resolve(Some(&root))?;
+        let idx = crate::discovery::ProjectIndex::discover(&pr)?;
+        let si = crate::structural::StructuralIndex::for_path(root.clone());
+        si.build_with_delta(&idx)?;
+        let mut conn = crate::structural::store::open_db(&root)?;
+        let cf = FakeEmbedder::new("det-model", 8);
+        crate::vector::sync_missing_vectors_for_root(&mut conn, &root, &cf).await?;
+        let qvec = cf.embed_query("query semantic search test").await?;
+        let fp = cf.fingerprint();
+        let first = crate::vector::search_brute(&conn, &qvec, &fp, 10)?;
+        for _ in 0..20 {
+            let next = crate::vector::search_brute(&conn, &qvec, &fp, 10)?;
+            assert_eq!(first.len(), next.len());
+            for (a, b) in first.iter().zip(next.iter()) {
+                assert_eq!(a.file, b.file);
+                assert_eq!(a.chunk_id, b.chunk_id);
+                assert_eq!(a.start_line, b.start_line);
+                assert!((a.score - b.score).abs() < 1e-6);
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn r5c_k_status_uses_configured_fingerprint() -> Result<()> {
+        // Verify configured_fingerprint reads env and vector counts are per fingerprint
+        let guard = std::sync::Mutex::new(());
+        let _g = guard.lock().unwrap();
+        let orig = std::env::var("CONTEXTD_EMBED_MODEL").ok();
+        std::env::set_var("CONTEXTD_EMBED_MODEL", "nomic-embed-text");
+        let fp = crate::embed::configured_fingerprint();
+        assert_eq!(fp.model_id, "nomic-embed-text");
+        assert_eq!(fp.dimension, 768);
+        assert_eq!(fp.version, "ollama-nomic-embed-text-v1");
+        // ensure different from all-minilm
+        std::env::set_var("CONTEXTD_EMBED_MODEL", "all-minilm");
+        let fp2 = crate::embed::configured_fingerprint();
+        assert_eq!(fp2.dimension, 384);
+        assert_ne!(fp.model_id, fp2.model_id);
+        // Vector count isolation: upsert for fp then count for other should be 0
+        let mut conn = open_in_memory()?;
+        let vec = vec![0.1f32; 768];
+        crate::vector::upsert_vector(&mut conn, "h", &fp, &vec)?;
+        assert_eq!(count_vectors(&conn, &fp)?, 1);
+        assert_eq!(count_vectors(&conn, &fp2)?, 0);
+        // restore
+        if let Some(v) = orig {
+            std::env::set_var("CONTEXTD_EMBED_MODEL", v);
+        } else {
+            std::env::remove_var("CONTEXTD_EMBED_MODEL");
+        }
         Ok(())
     }
 }

--- a/crates/context-index/src/vector.rs
+++ b/crates/context-index/src/vector.rs
@@ -282,7 +282,6 @@ pub async fn sync_missing_vectors_for_root_with_batch_size(
     let mut hashes: Vec<String> = by_hash.keys().cloned().collect();
     hashes.sort();
     // Prepare texts batching
-    let batch_size = batch_size;
     let mut total_embedded = 0usize;
     let mut total_calls = 0usize;
     let mut file_cache: std::collections::HashMap<String, String> =
@@ -383,7 +382,8 @@ pub async fn sync_changed_files_vectors(
         };
         let abs = root.join(file);
         let content = std::fs::read_to_string(&abs).unwrap_or_default();
-        let (reused, embedded) = sync_vectors_for_file(conn, file, &chunks, &content, embedder).await?;
+        let (reused, embedded) =
+            sync_vectors_for_file(conn, file, &chunks, &content, embedder).await?;
         total_reused += reused;
         total_embedded += embedded;
         if embedded > 0 {
@@ -1227,10 +1227,9 @@ mod tests {
         let mut conn = crate::structural::store::open_db(&root)?;
         let calls = Arc::new(AtomicUsize::new(0));
         let ff = FailingFake::new("j-model", 8, 2, calls.clone());
-        let res = crate::vector::sync_missing_vectors_for_root_with_batch_size(
-            &mut conn, &root, &ff, 8,
-        )
-        .await;
+        let res =
+            crate::vector::sync_missing_vectors_for_root_with_batch_size(&mut conn, &root, &ff, 8)
+                .await;
         assert!(res.is_err(), "second batch should fail");
         // first batch 8 should have persisted
         let fp = ff.fingerprint();
@@ -1248,10 +1247,8 @@ mod tests {
         let docs2 = Arc::new(AtomicUsize::new(0));
         let cf = CountingFake::new("j-model", 8, calls2.clone(), docs2.clone());
         let (reused, embedded, calls_n, _docs) =
-            crate::vector::sync_missing_vectors_for_root_with_batch_size(
-                &mut conn, &root, &cf, 8,
-            )
-            .await?;
+            crate::vector::sync_missing_vectors_for_root_with_batch_size(&mut conn, &root, &cf, 8)
+                .await?;
         assert_eq!(
             embedded, 8,
             "retry should embed only missing 8, got {}",

--- a/crates/contextd/Cargo.toml
+++ b/crates/contextd/Cargo.toml
@@ -25,6 +25,7 @@ schemars = { workspace = true }
 reqwest = { workspace = true }
 toml = { workspace = true }
 clap = { workspace = true }
+async-trait = { workspace = true }
 
 [features]
 legacy-v2 = []

--- a/crates/contextd/src/cli.rs
+++ b/crates/contextd/src/cli.rs
@@ -262,9 +262,18 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
                 println!("symbols: {}", st.symbols);
                 println!("BM25 documents: {}", st.bm25_documents);
                 println!("vectors: {}", st.vector_count);
+                println!("eligible chunks: {}", st.eligible_chunk_count);
+                println!("missing vectors: {}", st.missing_vector_count);
+                println!("stale vectors: {}", st.stale_vector_count);
                 println!("embedding model: {}", st.embedding_model);
+                println!("embedding dimension: {}", st.embedding_dimension);
                 println!("embedding runtime: {}", st.embedding_runtime);
                 println!("semantic available: {}", st.semantic_available);
+                println!(
+                    "semantic backend available: {}",
+                    st.semantic_backend_available
+                );
+                println!("semantic index ready: {}", st.semantic_index_ready);
                 println!("watcher: {}", st.watcher_state);
                 if let Some(g) = st.index_generation {
                     println!("generation: {}", g);

--- a/crates/contextd/src/cli.rs
+++ b/crates/contextd/src/cli.rs
@@ -57,6 +57,12 @@ pub enum Command {
     Status,
     /// Run MCP stdio server (long-lived)
     Mcp,
+    /// Build or update index (use --semantic for full vector backfill)
+    Index {
+        /// Also build full semantic vectors (explicit, may take minutes for large repos)
+        #[arg(long)]
+        semantic: bool,
+    },
 }
 
 fn opts(cli: &Cli) -> SearchOptions {
@@ -281,6 +287,44 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
                 if let Some(v) = st.store_schema_version {
                     println!("schema version: {}", v);
                 }
+            }
+        }
+        Some(Command::Index { semantic }) => {
+            let svc = ContextService::new(root).await?;
+            let stats = if semantic {
+                svc.full_semantic_index().await?
+            } else {
+                svc.reconcile().await?
+            };
+            if is_json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "discovered": stats.discovered,
+                        "changed_files": stats.changed_files,
+                        "deleted_files": stats.deleted_files,
+                        "vectors_created": stats.vectors_created,
+                        "vectors_reused": stats.vectors_reused,
+                        "embedding_calls": stats.embedding_calls,
+                        "elapsed_ms": stats.elapsed_ms,
+                    }))?
+                );
+            } else {
+                println!(
+                    "reconcile: discovered {} changed {} deleted {} vectors_created {} reused {} calls {} elapsed {}ms",
+                    stats.discovered,
+                    stats.changed_files,
+                    stats.deleted_files,
+                    stats.vectors_created,
+                    stats.vectors_reused,
+                    stats.embedding_calls,
+                    stats.elapsed_ms
+                );
+                let st = svc.status().await?;
+                println!(
+                    "status: ready {} missing {} eligible {} vectors {}",
+                    st.semantic_index_ready, st.missing_vector_count, st.eligible_chunk_count, st.vector_count
+                );
             }
         }
         None => {

--- a/crates/contextd/src/cli.rs
+++ b/crates/contextd/src/cli.rs
@@ -323,7 +323,10 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
                 let st = svc.status().await?;
                 println!(
                     "status: ready {} missing {} eligible {} vectors {}",
-                    st.semantic_index_ready, st.missing_vector_count, st.eligible_chunk_count, st.vector_count
+                    st.semantic_index_ready,
+                    st.missing_vector_count,
+                    st.eligible_chunk_count,
+                    st.vector_count
                 );
             }
         }

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -670,108 +670,102 @@ pub async fn retrieve_context(
 
     // Native vector retrieval — REAL semantic only, FakeEmbedder is test-only
     if run_semantic {
-        let t_sem = Instant::now();
-        // Production uses genuine Ollama embedding; Fake is test-only and never used here
-        // Selected winner from real benchmark: all-minilm (384d, Apache-2.0) beats nomic on R@1/MRR with lower memory/disk
-        let embedder: std::sync::Arc<dyn context_index::embed::Embedder> = {
-            let model =
-                std::env::var("CONTEXTD_EMBED_MODEL").unwrap_or_else(|_| "all-minilm".to_string());
-            if model == "nomic-embed-text" {
-                std::sync::Arc::new(context_index::embed::OllamaEmbedder::nomic())
-            } else if model == "all-minilm" {
-                std::sync::Arc::new(context_index::embed::OllamaEmbedder::with_model(
-                    "all-minilm",
-                    384,
-                ))
-            } else {
-                std::sync::Arc::new(context_index::embed::OllamaEmbedder::with_model(
-                    &model, 768,
-                ))
-            }
-        };
-        let fp = embedder.fingerprint();
-        // Check model change invalidation
-        let conn = structural_store::open_db_async(project.root.clone()).await?;
-        let _ = context_index::vector::invalidate_stale_model(&conn, &fp);
-        let semantic_queries: Vec<String> = if !plan.semantic_queries.is_empty() {
-            plan.semantic_queries.clone()
-        } else if classified.query_type == QueryType::Symbol
-            && suff == EvidenceSufficiency::Insufficient
-        {
-            vec![query.to_string()]
+        // respect semantic disable flag without changing ranking
+        let semantic_disabled = std::env::var("CONTEXTD_SEMANTIC_ENABLED")
+            .map(|v| v == "0" || v.to_lowercase() == "false")
+            .unwrap_or(false);
+        if semantic_disabled {
+            retrievers_used.push("rust-semantic:disabled".into());
+            semantic_ms = 0;
         } else {
-            vec![]
-        };
-        for sq in &semantic_queries {
-            let q = sq.clone();
-            // Embed query without holding DB connection (Connection is !Send)
-            let qvec = {
-                let cached = context_index::embed::QUERY_CACHE.get(&fp, &q).await;
-                if let Some(v) = cached {
-                    v
-                } else {
-                    match embedder.embed_query(&q).await {
-                        Ok(v) => {
-                            context_index::embed::QUERY_CACHE
-                                .insert(&fp, &q, v.clone())
-                                .await;
-                            v
-                        }
-                        Err(e) => {
-                            tracing::debug!(error=%e, "query embed failed");
-                            retrievers_used.push("rust-semantic:0".into());
-                            continue;
-                        }
-                    }
-                }
-            };
-            // Now open DB for brute search (moved off async executor thread)
+            let t_sem = Instant::now();
+            // Use canonical configured embedder/fingerprint (CONTEXTD_EMBED_MODEL drives both indexing and query)
+            let embedder: std::sync::Arc<dyn context_index::embed::Embedder> =
+                std::sync::Arc::new(context_index::embed::configured_embedder());
+            let fp = embedder.fingerprint();
+            // Check model change invalidation
             let conn = structural_store::open_db_async(project.root.clone()).await?;
-            let cnt = context_index::vector::count_vectors(&conn, &fp).unwrap_or(0);
-            if cnt == 0 {
-                tracing::debug!("no vectors for model {}, skipping semantic", fp.model_id);
-                retrievers_used.push(format!("rust-semantic:0:{}", fp.model_id));
-                continue;
-            }
-            match context_index::vector::search_brute(&conn, &qvec, &fp, 10) {
-                Ok(results) => {
-                    for (rank, vc) in results.into_iter().enumerate() {
-                        let text = load_file_snippet(&project.root, &vc.file, vc.start_line)
-                            .await
-                            .unwrap_or_else(|| {
-                                format!("{} {}", vc.file, vc.symbol.clone().unwrap_or_default())
-                            });
-                        let ev = Evidence {
-                            source: context_rank::types::RetrievalSource::Semantic,
-                            file: vc.file.clone(),
-                            start_line: Some(vc.start_line),
-                            end_line: Some(vc.end_line),
-                            symbol: vc.symbol.clone(),
-                            symbol_kind: None,
-                            text: Some(text),
-                            score: Some(vc.score),
-                            relation: Some(context_rank::types::EvidenceRelation::Unknown),
-                            authority_score: None,
-                            final_score: None,
-                            provenance: Some("rust:semantic".into()),
-                            metadata: None,
-                        };
-                        vector_candidates.push((ev, rank + 1, vc.score));
+            let _ = context_index::vector::invalidate_stale_model(&conn, &fp);
+            let semantic_queries: Vec<String> = if !plan.semantic_queries.is_empty() {
+                plan.semantic_queries.clone()
+            } else if classified.query_type == QueryType::Symbol
+                && suff == EvidenceSufficiency::Insufficient
+            {
+                vec![query.to_string()]
+            } else {
+                vec![]
+            };
+            for sq in &semantic_queries {
+                let q = sq.clone();
+                // Embed query without holding DB connection (Connection is !Send)
+                let qvec = {
+                    let cached = context_index::embed::QUERY_CACHE.get(&fp, &q).await;
+                    if let Some(v) = cached {
+                        v
+                    } else {
+                        match embedder.embed_query(&q).await {
+                            Ok(v) => {
+                                context_index::embed::QUERY_CACHE
+                                    .insert(&fp, &q, v.clone())
+                                    .await;
+                                v
+                            }
+                            Err(e) => {
+                                tracing::debug!(error=%e, "query embed failed");
+                                retrievers_used.push("rust-semantic:0".into());
+                                continue;
+                            }
+                        }
                     }
-                    retrievers_used.push(format!(
-                        "rust-semantic:{}:{}",
-                        q.chars().take(15).collect::<String>(),
-                        vector_candidates.len()
-                    ));
-                    break;
+                };
+                // Now open DB for brute search (moved off async executor thread)
+                let conn = structural_store::open_db_async(project.root.clone()).await?;
+                let cnt = context_index::vector::count_vectors(&conn, &fp).unwrap_or(0);
+                if cnt == 0 {
+                    tracing::debug!("no vectors for model {}, skipping semantic", fp.model_id);
+                    retrievers_used.push(format!("rust-semantic:0:{}", fp.model_id));
+                    continue;
                 }
-                Err(e) => {
-                    tracing::debug!(error=%e, "vector search failed");
-                    retrievers_used.push("rust-semantic:0".into());
+                match context_index::vector::search_brute(&conn, &qvec, &fp, 10) {
+                    Ok(results) => {
+                        for (rank, vc) in results.into_iter().enumerate() {
+                            let text = load_file_snippet(&project.root, &vc.file, vc.start_line)
+                                .await
+                                .unwrap_or_else(|| {
+                                    format!("{} {}", vc.file, vc.symbol.clone().unwrap_or_default())
+                                });
+                            let ev = Evidence {
+                                source: context_rank::types::RetrievalSource::Semantic,
+                                file: vc.file.clone(),
+                                start_line: Some(vc.start_line),
+                                end_line: Some(vc.end_line),
+                                symbol: vc.symbol.clone(),
+                                symbol_kind: None,
+                                text: Some(text),
+                                score: Some(vc.score),
+                                relation: Some(context_rank::types::EvidenceRelation::Unknown),
+                                authority_score: None,
+                                final_score: None,
+                                provenance: Some("rust:semantic".into()),
+                                metadata: None,
+                            };
+                            vector_candidates.push((ev, rank + 1, vc.score));
+                        }
+                        retrievers_used.push(format!(
+                            "rust-semantic:{}:{}",
+                            q.chars().take(15).collect::<String>(),
+                            vector_candidates.len()
+                        ));
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::debug!(error=%e, "vector search failed");
+                        retrievers_used.push("rust-semantic:0".into());
+                    }
                 }
             }
+            semantic_ms = t_sem.elapsed().as_millis();
         }
-        semantic_ms = t_sem.elapsed().as_millis();
     } else {
         retrievers_used.push("rust-semantic:skipped".into());
     }

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -140,6 +140,13 @@ impl ContextService {
         &self,
         override_embedder: Option<Arc<dyn Embedder>>,
     ) -> Result<ReconcileStats, ContextError> {
+        self.reconcile_full_inner(override_embedder).await
+    }
+
+    async fn reconcile_full_inner(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<ReconcileStats, ContextError> {
         let _guard = self.build_lock.lock().await;
         let t0 = std::time::Instant::now();
         let root = ProjectRoot::resolve(Some(&self.root))
@@ -157,36 +164,29 @@ impl ContextService {
         .map_err(|e| ContextError::Internal(format!("structural build failed: {e}")))?;
 
         let _elapsed_struct = t0.elapsed().as_millis();
-        // Semantic reconcile — Ollama-free structural remains independent
         let mut vectors_created = 0usize;
         let mut vectors_reused = 0usize;
         let mut embedding_calls = 0usize;
 
-        // Determine fingerprint and backend availability
         let fingerprint = if let Some(ref emb) = override_embedder {
             emb.fingerprint()
         } else {
             context_index::embed::configured_fingerprint()
         };
         let backend_available = if override_embedder.is_some() {
-            // test mode: if embedder provided, consider backend available
             true
         } else {
             context_index::embed::is_configured_model_available().await
         };
 
         if backend_available {
-            // Use override embedder if provided else configured ollama embedder
             let embedder: Arc<dyn Embedder> = if let Some(e) = override_embedder {
                 e
             } else {
                 Arc::new(context_index::embed::configured_embedder())
             };
-            // Open DB for vector sync
             match structural_store::open_db(root.path()) {
                 Ok(mut conn) => {
-                    // Sync missing vectors for current fingerprint (handles initial, no-change, one-file, partial)
-                    // We use root-aware sync which reads file contents for missing hashes
                     match context_index::vector::sync_missing_vectors_for_root(
                         &mut conn,
                         root.path(),
@@ -201,10 +201,8 @@ impl ContextService {
                         }
                         Err(e) => {
                             tracing::warn!(error=%e, "semantic sync failed, structural still ok");
-                            // keep ready false, missing truthful
                         }
                     }
-                    // Also ensure orphan GC after sync (sync_missing already does, but for delete case where no missing, still need GC)
                     let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
                 }
                 Err(e) => {
@@ -227,10 +225,105 @@ impl ContextService {
         })
     }
 
-    /// Cheap reconcile — discovery + incremental structural/BM25 + semantic if available.
+    async fn reconcile_fast_inner(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<ReconcileStats, ContextError> {
+        let _guard = self.build_lock.lock().await;
+        let t0 = std::time::Instant::now();
+        let root = ProjectRoot::resolve(Some(&self.root))
+            .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
+        let idx =
+            ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
+        let root_path = root.path().to_path_buf();
+        let idx_clone = idx.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            let si = context_index::structural::StructuralIndex::for_path(root_path);
+            si.build_with_delta(&idx_clone)
+        })
+        .await
+        .map_err(|e| ContextError::Internal(format!("structural build panicked: {e}")))?
+        .map_err(|e| ContextError::Internal(format!("structural build failed: {e}")))?;
+
+        let mut vectors_created = 0usize;
+        let mut vectors_reused = 0usize;
+        let mut embedding_calls = 0usize;
+
+        let fingerprint = if let Some(ref emb) = override_embedder {
+            emb.fingerprint()
+        } else {
+            context_index::embed::configured_fingerprint()
+        };
+        let backend_available = if override_embedder.is_some() {
+            true
+        } else {
+            context_index::embed::is_configured_model_available().await
+        };
+
+        if backend_available {
+            let embedder: Arc<dyn Embedder> = if let Some(e) = override_embedder {
+                e
+            } else {
+                Arc::new(context_index::embed::configured_embedder())
+            };
+            match structural_store::open_db(root.path()) {
+                Ok(mut conn) => {
+                    // Fast path: only incremental when previously ready and small delta
+                    let eligible = context_index::vector::eligible_chunk_count(&conn).unwrap_or(0);
+                    let missing_before = context_index::vector::missing_vector_count(&conn, &fingerprint).unwrap_or(0);
+                    let is_ready_before = eligible > 0 && missing_before == 0;
+                    let small_delta = outcome.changed_files.len() <= 10 && outcome.deleted_files.len() <= 10;
+                    if is_ready_before && small_delta && !outcome.changed_files.is_empty() {
+                        match context_index::vector::sync_changed_files_vectors(
+                            &mut conn,
+                            root.path(),
+                            &outcome.changed_files,
+                            embedder.as_ref(),
+                        )
+                        .await
+                        {
+                            Ok((reused, embedded, calls)) => {
+                                vectors_reused = reused;
+                                vectors_created = embedded;
+                                embedding_calls = calls;
+                            }
+                            Err(e) => {
+                                tracing::warn!(error=%e, "incremental semantic sync failed");
+                            }
+                        }
+                    } else {
+                        // Cold or no-change or large delta: do not full backfill, just GC if deleted
+                        if !outcome.deleted_files.is_empty() {
+                            let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
+                        }
+                    }
+                    // Ensure GC for deleted files even when skipping embedding
+                    if !outcome.deleted_files.is_empty() {
+                        let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error=%e, "open_db for fast semantic sync failed");
+                }
+            }
+        }
+
+        let elapsed = t0.elapsed().as_millis();
+        Ok(ReconcileStats {
+            discovered: idx.stats.discovered,
+            changed_files: outcome.changed_files.len(),
+            deleted_files: outcome.deleted_files.len(),
+            elapsed_ms: elapsed,
+            vectors_created,
+            vectors_reused,
+            embedding_calls,
+        })
+    }
+
+    /// Cheap reconcile — discovery + incremental structural/BM25 + semantic if available (fast, incremental only).
     /// Target <100ms for no-change. Serialized to avoid concurrent SQLite writes.
     pub async fn reconcile(&self) -> Result<ReconcileStats, ContextError> {
-        self.reconcile_inner(None).await
+        self.reconcile_fast_inner(None).await
     }
 
     #[cfg(test)]
@@ -241,12 +334,24 @@ impl ContextService {
         self.reconcile_inner(Some(embedder)).await
     }
 
+    pub async fn full_semantic_index(&self) -> Result<ReconcileStats, ContextError> {
+        self.reconcile_full_inner(None).await
+    }
+
+    #[cfg(test)]
+    pub async fn full_semantic_index_with_embedder(
+        &self,
+        embedder: std::sync::Arc<dyn context_index::embed::Embedder>,
+    ) -> Result<ReconcileStats, ContextError> {
+        self.reconcile_full_inner(Some(embedder)).await
+    }
+
     pub async fn search(
         &self,
         query: &str,
         opts: SearchOptions,
     ) -> Result<ContextResult, ContextError> {
-        self.reconcile()
+        self.reconcile_fast_inner(None)
             .await
             .map_err(|e| ContextError::Internal(format!("reconcile failed: {e}")))?;
         let root = ProjectRoot::resolve(Some(&self.root))
@@ -673,5 +778,88 @@ mod tests {
         let out3 = si.build_with_delta(&idx3).unwrap();
         assert_eq!(out3.changed_files.len(), 0);
         assert_eq!(out3.deleted_files, vec!["a.py".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn cold_search_does_not_full_backfill() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        for i in 0..16 {
+            std::fs::write(root.join(format!("f{i}.py")), format!("def foo_{i}():\n    x={i}\n").as_bytes()).unwrap();
+        }
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        // Use fast reconcile with counting fake (should embed 0 for cold)
+        use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+        struct CountingFake2 {
+            inner: context_index::embed::FakeEmbedder,
+            calls: Arc<AtomicUsize>,
+        }
+        #[async_trait::async_trait]
+        impl context_index::embed::Embedder for CountingFake2 {
+            fn model_id(&self) -> &str { self.inner.model_id() }
+            fn dimension(&self) -> usize { self.inner.dimension() }
+            fn version(&self) -> &str { self.inner.version() }
+            async fn embed_query(&self, q: &str) -> anyhow::Result<Vec<f32>> { self.inner.embed_query(q).await }
+            async fn embed_documents(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.inner.embed_documents(texts).await
+            }
+        }
+        let calls = Arc::new(AtomicUsize::new(0));
+        let fake = Arc::new(CountingFake2 { inner: context_index::embed::FakeEmbedder::new("cold-test", 8), calls: calls.clone() });
+        // fast reconcile should NOT embed all 16 (cold)
+        let stats = svc.reconcile_fast_inner(Some(fake.clone())).await.unwrap();
+        assert_eq!(stats.vectors_created, 0, "cold fast reconcile should embed 0");
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        // status should be not ready
+        let conn = context_index::structural::store::open_db(&root).unwrap();
+        let fp = fake.fingerprint();
+        assert!(!context_index::vector::is_semantic_ready(&conn, &fp, true).unwrap());
+        assert!(context_index::vector::missing_vector_count(&conn, &fp).unwrap() > 0);
+        // lexical search should still succeed
+        let res = svc.search("foo_0", crate::service::SearchOptions::default()).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn explicit_full_semantic_index_covers_all() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        for i in 0..8 {
+            std::fs::write(root.join(format!("a{i}.py")), format!("def bar_{i}():\n    y={i}\n").as_bytes()).unwrap();
+        }
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let fake = Arc::new(context_index::embed::FakeEmbedder::new("explicit-test", 8));
+        let stats = svc.full_semantic_index_with_embedder(fake.clone()).await.unwrap();
+        assert!(stats.vectors_created > 0);
+        let conn = context_index::structural::store::open_db(&root).unwrap();
+        let fp = fake.fingerprint();
+        assert_eq!(context_index::vector::missing_vector_count(&conn, &fp).unwrap(), 0);
+        assert!(context_index::vector::is_semantic_ready(&conn, &fp, true).unwrap());
+    }
+
+    #[tokio::test]
+    async fn incremental_one_file_change_only_that_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::write(root.join("a.py"), b"def foo():\n    x=1\n").unwrap();
+        std::fs::write(root.join("b.py"), b"def bar():\n    y=2\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let fake = Arc::new(context_index::embed::FakeEmbedder::new("inc-test", 8));
+        // first full
+        svc.full_semantic_index_with_embedder(fake.clone()).await.unwrap();
+        // change one file
+        std::fs::write(root.join("a.py"), b"def foo():\n    x=999\n").unwrap();
+        // fast reconcile should embed only changed file
+        let stats = svc.reconcile_fast_inner(Some(fake.clone())).await.unwrap();
+        assert_eq!(stats.changed_files, 1);
+        assert_eq!(stats.vectors_created, 1, "only changed chunk");
+        // no-change after
+        let stats2 = svc.reconcile_fast_inner(Some(fake.clone())).await.unwrap();
+        assert_eq!(stats2.changed_files, 0);
+        assert_eq!(stats2.vectors_created, 0);
     }
 }

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -233,6 +233,22 @@ impl ContextService {
         let t0 = std::time::Instant::now();
         let root = ProjectRoot::resolve(Some(&self.root))
             .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
+        // Capture semantic readiness BEFORE structural mutation (correct for incremental)
+        let fingerprint = if let Some(ref emb) = override_embedder {
+            emb.fingerprint()
+        } else {
+            context_index::embed::configured_fingerprint()
+        };
+        let (was_semantic_ready, _was_missing_before) = if let Ok(conn) =
+            structural_store::open_db(root.path())
+        {
+            let eligible_before = context_index::vector::eligible_chunk_count(&conn).unwrap_or(0);
+            let missing_before =
+                context_index::vector::missing_vector_count(&conn, &fingerprint).unwrap_or(0);
+            (eligible_before > 0 && missing_before == 0, missing_before)
+        } else {
+            (false, 0)
+        };
         let idx =
             ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
         let root_path = root.path().to_path_buf();
@@ -249,11 +265,6 @@ impl ContextService {
         let mut vectors_reused = 0usize;
         let mut embedding_calls = 0usize;
 
-        let fingerprint = if let Some(ref emb) = override_embedder {
-            emb.fingerprint()
-        } else {
-            context_index::embed::configured_fingerprint()
-        };
         let backend_available = if override_embedder.is_some() {
             true
         } else {
@@ -268,12 +279,10 @@ impl ContextService {
             };
             match structural_store::open_db(root.path()) {
                 Ok(mut conn) => {
-                    // Fast path: only incremental when previously ready and small delta
-                    let eligible = context_index::vector::eligible_chunk_count(&conn).unwrap_or(0);
-                    let missing_before = context_index::vector::missing_vector_count(&conn, &fingerprint).unwrap_or(0);
-                    let is_ready_before = eligible > 0 && missing_before == 0;
-                    let small_delta = outcome.changed_files.len() <= 10 && outcome.deleted_files.len() <= 10;
-                    if is_ready_before && small_delta && !outcome.changed_files.is_empty() {
+                    // Fast path: only incremental when previously ready and small delta (using pre-mutation readiness)
+                    let small_delta =
+                        outcome.changed_files.len() <= 10 && outcome.deleted_files.len() <= 10;
+                    if was_semantic_ready && small_delta && !outcome.changed_files.is_empty() {
                         match context_index::vector::sync_changed_files_vectors(
                             &mut conn,
                             root.path(),
@@ -786,31 +795,52 @@ mod tests {
         let root = tmp.path().to_path_buf();
         std::fs::create_dir_all(root.join(".git")).unwrap();
         for i in 0..16 {
-            std::fs::write(root.join(format!("f{i}.py")), format!("def foo_{i}():\n    x={i}\n").as_bytes()).unwrap();
+            std::fs::write(
+                root.join(format!("f{i}.py")),
+                format!("def foo_{i}():\n    x={i}\n").as_bytes(),
+            )
+            .unwrap();
         }
         let svc = ContextService::new(Some(root.clone())).await.unwrap();
         // Use fast reconcile with counting fake (should embed 0 for cold)
-        use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
         struct CountingFake2 {
             inner: context_index::embed::FakeEmbedder,
             calls: Arc<AtomicUsize>,
         }
         #[async_trait::async_trait]
         impl context_index::embed::Embedder for CountingFake2 {
-            fn model_id(&self) -> &str { self.inner.model_id() }
-            fn dimension(&self) -> usize { self.inner.dimension() }
-            fn version(&self) -> &str { self.inner.version() }
-            async fn embed_query(&self, q: &str) -> anyhow::Result<Vec<f32>> { self.inner.embed_query(q).await }
+            fn model_id(&self) -> &str {
+                self.inner.model_id()
+            }
+            fn dimension(&self) -> usize {
+                self.inner.dimension()
+            }
+            fn version(&self) -> &str {
+                self.inner.version()
+            }
+            async fn embed_query(&self, q: &str) -> anyhow::Result<Vec<f32>> {
+                self.inner.embed_query(q).await
+            }
             async fn embed_documents(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 self.inner.embed_documents(texts).await
             }
         }
         let calls = Arc::new(AtomicUsize::new(0));
-        let fake = Arc::new(CountingFake2 { inner: context_index::embed::FakeEmbedder::new("cold-test", 8), calls: calls.clone() });
+        let fake = Arc::new(CountingFake2 {
+            inner: context_index::embed::FakeEmbedder::new("cold-test", 8),
+            calls: calls.clone(),
+        });
         // fast reconcile should NOT embed all 16 (cold)
         let stats = svc.reconcile_fast_inner(Some(fake.clone())).await.unwrap();
-        assert_eq!(stats.vectors_created, 0, "cold fast reconcile should embed 0");
+        assert_eq!(
+            stats.vectors_created, 0,
+            "cold fast reconcile should embed 0"
+        );
         assert_eq!(calls.load(Ordering::SeqCst), 0);
         // status should be not ready
         let conn = context_index::structural::store::open_db(&root).unwrap();
@@ -818,7 +848,9 @@ mod tests {
         assert!(!context_index::vector::is_semantic_ready(&conn, &fp, true).unwrap());
         assert!(context_index::vector::missing_vector_count(&conn, &fp).unwrap() > 0);
         // lexical search should still succeed
-        let res = svc.search("foo_0", crate::service::SearchOptions::default()).await;
+        let res = svc
+            .search("foo_0", crate::service::SearchOptions::default())
+            .await;
         assert!(res.is_ok());
     }
 
@@ -828,15 +860,25 @@ mod tests {
         let root = tmp.path().to_path_buf();
         std::fs::create_dir_all(root.join(".git")).unwrap();
         for i in 0..8 {
-            std::fs::write(root.join(format!("a{i}.py")), format!("def bar_{i}():\n    y={i}\n").as_bytes()).unwrap();
+            std::fs::write(
+                root.join(format!("a{i}.py")),
+                format!("def bar_{i}():\n    y={i}\n").as_bytes(),
+            )
+            .unwrap();
         }
         let svc = ContextService::new(Some(root.clone())).await.unwrap();
         let fake = Arc::new(context_index::embed::FakeEmbedder::new("explicit-test", 8));
-        let stats = svc.full_semantic_index_with_embedder(fake.clone()).await.unwrap();
+        let stats = svc
+            .full_semantic_index_with_embedder(fake.clone())
+            .await
+            .unwrap();
         assert!(stats.vectors_created > 0);
         let conn = context_index::structural::store::open_db(&root).unwrap();
         let fp = fake.fingerprint();
-        assert_eq!(context_index::vector::missing_vector_count(&conn, &fp).unwrap(), 0);
+        assert_eq!(
+            context_index::vector::missing_vector_count(&conn, &fp).unwrap(),
+            0
+        );
         assert!(context_index::vector::is_semantic_ready(&conn, &fp, true).unwrap());
     }
 
@@ -850,7 +892,9 @@ mod tests {
         let svc = ContextService::new(Some(root.clone())).await.unwrap();
         let fake = Arc::new(context_index::embed::FakeEmbedder::new("inc-test", 8));
         // first full
-        svc.full_semantic_index_with_embedder(fake.clone()).await.unwrap();
+        svc.full_semantic_index_with_embedder(fake.clone())
+            .await
+            .unwrap();
         // change one file
         std::fs::write(root.join("a.py"), b"def foo():\n    x=999\n").unwrap();
         // fast reconcile should embed only changed file

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -60,7 +60,11 @@ impl Direction {
 pub struct ReconcileStats {
     pub discovered: usize,
     pub changed_files: usize,
+    pub deleted_files: usize,
     pub elapsed_ms: u128,
+    pub vectors_created: usize,
+    pub vectors_reused: usize,
+    pub embedding_calls: usize,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -79,8 +83,16 @@ pub struct StatusReport {
     pub bm25_documents: usize,
     pub vector_count: usize,
     pub embedding_model: String,
+    pub embedding_dimension: usize,
     pub embedding_runtime: String,
     pub semantic_available: bool,
+    #[serde(rename = "semanticBackendAvailable")]
+    pub semantic_backend_available: bool,
+    #[serde(rename = "semanticIndexReady")]
+    pub semantic_index_ready: bool,
+    pub eligible_chunk_count: usize,
+    pub missing_vector_count: usize,
+    pub stale_vector_count: usize,
     pub watcher_state: String,
     pub store_schema_version: Option<u32>,
 }
@@ -124,31 +136,109 @@ impl ContextService {
         }
     }
 
-    /// Cheap reconcile — discovery + incremental structural/BM25.
-    /// Target <100ms for no-change. Serialized to avoid concurrent SQLite writes.
-    pub async fn reconcile(&self) -> Result<ReconcileStats, ContextError> {
+    async fn reconcile_inner(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<ReconcileStats, ContextError> {
         let _guard = self.build_lock.lock().await;
         let t0 = std::time::Instant::now();
         let root = ProjectRoot::resolve(Some(&self.root))
             .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
         let idx =
             ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
-        // Incremental structural build (hash skip) — spawn_blocking
         let root_path = root.path().to_path_buf();
         let idx_clone = idx.clone();
-        tokio::task::spawn_blocking(move || {
+        let outcome = tokio::task::spawn_blocking(move || {
             let si = context_index::structural::StructuralIndex::for_path(root_path);
-            si.build(&idx_clone)
+            si.build_with_delta(&idx_clone)
         })
         .await
         .map_err(|e| ContextError::Internal(format!("structural build panicked: {e}")))?
         .map_err(|e| ContextError::Internal(format!("structural build failed: {e}")))?;
+
+        let _elapsed_struct = t0.elapsed().as_millis();
+        // Semantic reconcile — Ollama-free structural remains independent
+        let mut vectors_created = 0usize;
+        let mut vectors_reused = 0usize;
+        let mut embedding_calls = 0usize;
+
+        // Determine fingerprint and backend availability
+        let fingerprint = if let Some(ref emb) = override_embedder {
+            emb.fingerprint()
+        } else {
+            context_index::embed::configured_fingerprint()
+        };
+        let backend_available = if override_embedder.is_some() {
+            // test mode: if embedder provided, consider backend available
+            true
+        } else {
+            context_index::embed::is_configured_model_available().await
+        };
+
+        if backend_available {
+            // Use override embedder if provided else configured ollama embedder
+            let embedder: Arc<dyn Embedder> = if let Some(e) = override_embedder {
+                e
+            } else {
+                Arc::new(context_index::embed::configured_embedder())
+            };
+            // Open DB for vector sync
+            match structural_store::open_db(root.path()) {
+                Ok(mut conn) => {
+                    // Sync missing vectors for current fingerprint (handles initial, no-change, one-file, partial)
+                    // We use root-aware sync which reads file contents for missing hashes
+                    match context_index::vector::sync_missing_vectors_for_root(
+                        &mut conn,
+                        root.path(),
+                        embedder.as_ref(),
+                    )
+                    .await
+                    {
+                        Ok((reused, created, calls, _docs)) => {
+                            vectors_reused = reused;
+                            vectors_created = created;
+                            embedding_calls = calls;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error=%e, "semantic sync failed, structural still ok");
+                            // keep ready false, missing truthful
+                        }
+                    }
+                    // Also ensure orphan GC after sync (sync_missing already does, but for delete case where no missing, still need GC)
+                    let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
+                }
+                Err(e) => {
+                    tracing::warn!(error=%e, "open_db for semantic sync failed");
+                }
+            }
+        } else {
+            tracing::debug!("semantic backend unavailable, skipping vector sync");
+        }
+
         let elapsed = t0.elapsed().as_millis();
         Ok(ReconcileStats {
             discovered: idx.stats.discovered,
-            changed_files: 0,
+            changed_files: outcome.changed_files.len(),
+            deleted_files: outcome.deleted_files.len(),
             elapsed_ms: elapsed,
+            vectors_created,
+            vectors_reused,
+            embedding_calls,
         })
+    }
+
+    /// Cheap reconcile — discovery + incremental structural/BM25 + semantic if available.
+    /// Target <100ms for no-change. Serialized to avoid concurrent SQLite writes.
+    pub async fn reconcile(&self) -> Result<ReconcileStats, ContextError> {
+        self.reconcile_inner(None).await
+    }
+
+    #[cfg(test)]
+    pub async fn reconcile_with_embedder(
+        &self,
+        embedder: Arc<dyn Embedder>,
+    ) -> Result<ReconcileStats, ContextError> {
+        self.reconcile_inner(Some(embedder)).await
     }
 
     pub async fn search(
@@ -218,8 +308,12 @@ impl ContextService {
         let mut symbols = 0usize;
         let mut bm25_docs = 0usize;
         let mut vector_count = 0usize;
+        let mut eligible = 0usize;
+        let mut missing = 0usize;
+        let mut stale = 0usize;
         let mut store_version = None;
 
+        let fingerprint = context_index::embed::configured_fingerprint();
         if let Ok(root) = ProjectRoot::resolve(Some(&self.root)) {
             if let Ok(conn) = structural_store::open_db(root.path()) {
                 if let Ok(gen) = structural_store::get_generation(&conn) {
@@ -228,25 +322,23 @@ impl ContextService {
                 if let Ok(cnt) = structural_store::count_symbols(&conn) {
                     symbols = cnt as usize;
                 }
+                if let Ok(cnt) = structural_store::count_files(&conn) {
+                    files_indexed = cnt as usize;
+                }
                 if let Ok(cnt) = context_index::bm25::count_bm25_docs(&conn) {
                     bm25_docs = cnt as usize;
                 }
-                if let Ok(v) = context_index::vector::count_vectors(
-                    &conn,
-                    &context_index::embed::OllamaEmbedder::with_model("all-minilm", 384)
-                        .fingerprint(),
-                ) {
-                    vector_count = v as usize;
-                }
-                // schema version if table exists
+                vector_count =
+                    context_index::vector::count_vectors(&conn, &fingerprint).unwrap_or(0) as usize;
+                eligible = context_index::vector::eligible_chunk_count(&conn).unwrap_or(0);
+                missing =
+                    context_index::vector::missing_vector_count(&conn, &fingerprint).unwrap_or(0);
+                stale = context_index::vector::stale_vector_count(&conn, &fingerprint).unwrap_or(0);
                 if let Ok(mut stmt) = conn.prepare("SELECT version FROM schema_version LIMIT 1") {
                     if let Ok(v) = stmt.query_row([], |r| r.get::<_, u32>(0)) {
                         store_version = Some(v);
                     }
                 }
-            }
-            if let Ok(idx) = ProjectIndex::discover(&root) {
-                files_indexed = idx.stats.discovered;
             }
         }
 
@@ -272,30 +364,21 @@ impl ContextService {
         .await
         .map_err(|e| ContextError::Internal(format!("git branch capture panicked: {e}")))?;
 
-        let model =
-            std::env::var("CONTEXTD_EMBED_MODEL").unwrap_or_else(|_| "all-minilm".to_string());
-        let semantic_available = {
-            let client = reqwest::Client::builder()
-                .timeout(std::time::Duration::from_millis(500))
-                .build();
-            if let Ok(c) = client {
-                let url = std::env::var("OLLAMA_HOST")
-                    .unwrap_or_else(|_| "http://localhost:11434".to_string())
-                    + "/api/tags";
-                match tokio::time::timeout(
-                    std::time::Duration::from_millis(800),
-                    c.get(&url).send(),
-                )
-                .await
-                {
-                    Ok(Ok(resp)) => resp.status().is_success(),
-                    _ => false,
-                }
-            } else {
+        let model = context_index::embed::configured_model_name();
+        let dim = fingerprint.dimension;
+        let semantic_backend_available =
+            context_index::embed::is_configured_model_available().await;
+        let semantic_index_ready = if !semantic_backend_available {
+            false
+        } else {
+            // need conn again for is_semantic_ready but we already computed missing/eligible
+            if eligible == 0 {
                 false
+            } else {
+                missing == 0
             }
         };
-        // watcher state — simple
+        let semantic_available = semantic_backend_available;
         let watcher_state = "rust-notify".to_string();
 
         let rust_version = env!("CARGO_PKG_RUST_VERSION").to_string();
@@ -317,12 +400,18 @@ impl ContextService {
             bm25_documents: bm25_docs,
             vector_count,
             embedding_model: model,
-            embedding_runtime: if semantic_available {
+            embedding_dimension: dim,
+            embedding_runtime: if semantic_backend_available {
                 "ollama".into()
             } else {
                 "none".into()
             },
             semantic_available,
+            semantic_backend_available,
+            semantic_index_ready,
+            eligible_chunk_count: eligible,
+            missing_vector_count: missing,
+            stale_vector_count: stale,
             watcher_state,
             store_schema_version: store_version,
         })
@@ -334,6 +423,7 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+    static ENV_GLOBAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[tokio::test]
     async fn concurrent_searches_serialized() {
@@ -377,5 +467,211 @@ mod tests {
             "error should mention reconcile, got: {}",
             err
         );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn backend_unavailable_lexical_still_works() {
+        let _env_guard = ENV_GLOBAL_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        // force semantic disabled via env
+        let orig = std::env::var("CONTEXTD_SEMANTIC_ENABLED").ok();
+        std::env::set_var("CONTEXTD_SEMANTIC_ENABLED", "0");
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let res = svc.reconcile().await;
+        assert!(
+            res.is_ok(),
+            "reconcile should succeed even when semantic disabled: {:?}",
+            res.err()
+        );
+        let st = svc.status().await.unwrap();
+        assert!(
+            !st.semantic_backend_available,
+            "backend should be reported unavailable when disabled"
+        );
+        assert!(
+            !st.semantic_index_ready,
+            "ready should be false when backend unavailable"
+        );
+        assert!(st.eligible_chunk_count >= st.missing_vector_count);
+        // lexical search should still work
+        let search = svc.search("foo", SearchOptions::default()).await;
+        assert!(
+            search.is_ok(),
+            "lexical search should succeed: {:?}",
+            search.err()
+        );
+        assert!(
+            !search.unwrap().evidence.is_empty(),
+            "should find foo via lexical"
+        );
+        // restore
+        if let Some(v) = orig {
+            std::env::set_var("CONTEXTD_SEMANTIC_ENABLED", v);
+        } else {
+            std::env::remove_var("CONTEXTD_SEMANTIC_ENABLED");
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_with_fake_embedder_initial_and_no_change() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        fs::write(root.join("b.py"), b"def bar():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let fake = std::sync::Arc::new(context_index::embed::FakeEmbedder::new("svc-test", 8));
+        let stats = svc.reconcile_with_embedder(fake.clone()).await.unwrap();
+        assert!(stats.changed_files >= 2 || stats.discovered >= 2);
+        // second reconcile no change should be 0 embedding (we check via missing)
+        let conn = context_index::structural::store::open_db(&root).unwrap();
+        let fp = fake.fingerprint();
+        let missing = context_index::vector::missing_vector_count(&conn, &fp).unwrap();
+        assert_eq!(missing, 0, "after initial, missing should be 0");
+        let fake2 = std::sync::Arc::new(context_index::embed::FakeEmbedder::new("svc-test", 8));
+        let stats2 = svc.reconcile_with_embedder(fake2.clone()).await.unwrap();
+        assert_eq!(
+            stats2.changed_files, 0,
+            "no-change should have 0 changed_files"
+        );
+        assert_eq!(stats2.deleted_files, 0);
+        // vector count stable
+        let conn2 = context_index::structural::store::open_db(&root).unwrap();
+        let cnt = context_index::vector::count_vectors(&conn2, &fp).unwrap();
+        assert!(cnt > 0);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn status_uses_configured_fingerprint_not_hardcoded() {
+        let _env_guard = ENV_GLOBAL_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let orig = std::env::var("CONTEXTD_EMBED_MODEL").ok();
+        std::env::set_var("CONTEXTD_EMBED_MODEL", "nomic-embed-text");
+        let fp = context_index::embed::configured_fingerprint();
+        assert_eq!(fp.model_id, "nomic-embed-text");
+        assert_eq!(fp.dimension, 768);
+        {
+            let mut conn = context_index::structural::store::open_db(&root).unwrap();
+            let pr = context_index::ProjectRoot::resolve(Some(&root)).unwrap();
+            let idx = context_index::ProjectIndex::discover(&pr).unwrap();
+            let si = context_index::structural::StructuralIndex::for_path(root.clone());
+            si.build_with_delta(&idx).unwrap();
+            let vec_data = vec![0.1f32; 768];
+            let conn2 = context_index::structural::store::open_db(&root).unwrap();
+            let hash: String = conn2
+                .query_row("SELECT content_hash FROM chunks LIMIT 1", [], |r| r.get(0))
+                .unwrap();
+            context_index::vector::upsert_vector(&mut conn, &hash, &fp, &vec_data).unwrap();
+        }
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let st = svc.status().await.unwrap();
+        assert_eq!(st.embedding_model, "nomic-embed-text");
+        assert_eq!(st.embedding_dimension, 768);
+        let conn = context_index::structural::store::open_db(&root).unwrap();
+        let fp_all = context_index::embed::ModelFingerprint {
+            model_id: "all-minilm".into(),
+            version: "ollama-all-minilm-v1".into(),
+            dimension: 384,
+        };
+        let cnt_nomic = context_index::vector::count_vectors(&conn, &fp).unwrap();
+        let cnt_all = context_index::vector::count_vectors(&conn, &fp_all).unwrap();
+        assert!(cnt_nomic > 0);
+        assert_eq!(
+            cnt_all, 0,
+            "hardcoded all-minilm should not be used when nomic configured"
+        );
+        if let Some(v) = orig {
+            std::env::set_var("CONTEXTD_EMBED_MODEL", v);
+        } else {
+            std::env::remove_var("CONTEXTD_EMBED_MODEL");
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn daemon_reachable_model_unavailable_reports_unavailable() {
+        let _env_guard = ENV_GLOBAL_LOCK.lock().unwrap();
+        // mock Ollama tags server - handle 2 requests
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    let mut buf = [0u8; 2048];
+                    let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+                    let body = r#"{"models":[{"name":"all-minilm:latest"}]}"#;
+                    let resp = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}", body.len(), body);
+                    let _ = tokio::io::AsyncWriteExt::write_all(&mut socket, resp.as_bytes()).await;
+                }
+            }
+        });
+        let orig_host = std::env::var("OLLAMA_HOST").ok();
+        let orig_model = std::env::var("CONTEXTD_EMBED_MODEL").ok();
+        std::env::set_var("OLLAMA_HOST", format!("http://{}", addr));
+        // model that is NOT in tags
+        std::env::set_var("CONTEXTD_EMBED_MODEL", "nomic-embed-text");
+        // ensure semantic enabled
+        let orig_sem = std::env::var("CONTEXTD_SEMANTIC_ENABLED").ok();
+        std::env::remove_var("CONTEXTD_SEMANTIC_ENABLED");
+        let available = context_index::embed::is_configured_model_available().await;
+        assert!(
+            !available,
+            "nomic should be unavailable when tags only has all-minilm"
+        );
+        // now check all-minilm is available
+        std::env::set_var("CONTEXTD_EMBED_MODEL", "all-minilm");
+        let available2 = context_index::embed::is_configured_model_available().await;
+        assert!(available2, "all-minilm should be available");
+        server.abort();
+        if let Some(v) = orig_host {
+            std::env::set_var("OLLAMA_HOST", v);
+        } else {
+            std::env::remove_var("OLLAMA_HOST");
+        }
+        if let Some(v) = orig_model {
+            std::env::set_var("CONTEXTD_EMBED_MODEL", v);
+        } else {
+            std::env::remove_var("CONTEXTD_EMBED_MODEL");
+        }
+        if let Some(v) = orig_sem {
+            std::env::set_var("CONTEXTD_SEMANTIC_ENABLED", v);
+        } else {
+            std::env::remove_var("CONTEXTD_SEMANTIC_ENABLED");
+        }
+    }
+
+    #[tokio::test]
+    async fn structural_delta_exposed() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::write(root.join("a.py"), b"def foo(): pass").unwrap();
+        let pr = context_index::ProjectRoot::resolve(Some(&root)).unwrap();
+        let idx = context_index::ProjectIndex::discover(&pr).unwrap();
+        let si = context_index::structural::StructuralIndex::for_path(root.clone());
+        let out1 = si.build_with_delta(&idx).unwrap();
+        assert!(!out1.changed_files.is_empty());
+        assert!(out1.deleted_files.is_empty());
+        // no change second build
+        let pr2 = context_index::ProjectRoot::resolve(Some(&root)).unwrap();
+        let idx2 = context_index::ProjectIndex::discover(&pr2).unwrap();
+        let out2 = si.build_with_delta(&idx2).unwrap();
+        assert_eq!(out2.changed_files.len(), 0);
+        assert_eq!(out2.deleted_files.len(), 0);
+        // delete file
+        std::fs::remove_file(root.join("a.py")).unwrap();
+        let pr3 = context_index::ProjectRoot::resolve(Some(&root)).unwrap();
+        let idx3 = context_index::ProjectIndex::discover(&pr3).unwrap();
+        let out3 = si.build_with_delta(&idx3).unwrap();
+        assert_eq!(out3.changed_files.len(), 0);
+        assert_eq!(out3.deleted_files, vec!["a.py".to_string()]);
     }
 }


### PR DESCRIPTION
# R5.1-C Production Semantic Indexing — FINAL CLOSURE

**Base:** `f4d9b68`
**New HEAD:** `048b2523f40afaf37e4cf99299408eab013be240` (was `1d02a94`, now fixed)
**Branch:** `r5.1c/semantic-indexing`
**Status:** `semanticIndexReady` truthful, `was_semantic_ready` captured **before** `build_with_delta()`

## What was fixed (blockers)

**1. Partial-failure test batch-independent**
- Exposed `sync_missing_vectors_for_root_with_batch_size(conn,root,embedder,batch_size)` — prod `256`, tests `8`.
- Old test assumed prod 64 → 70 docs, fail on 2nd batch (64+6) → brittle.
- New test: 16 docs, batch 8 → 2 batches, fail 2nd → 8 persisted / 8 missing → retry 8. Passes at `048b252`.

**2. Cold search no longer blocks on full 40k backfill**
- `search()` → `reconcile_fast_inner`: structural delta + **incremental only** when `was_semantic_ready && small_delta(<=10)` → `sync_changed_files_vectors(changed_files)`.
- Cold repo (`eligible_before==0` → `was_ready=false`) → `vectors_created 0`, `missing>0`, `ready false`, lexical still works.
- Partially indexed (`missing_before>0` → `was_ready=false`) → no implicit full backfill.
- One-file edit after ready (`was_ready=true`, `changed=1`) → 1 hash embedded, ready restored.
- Model change (new fingerprint `was_ready=false`) → requires explicit `contextd index --semantic`.

**3. Explicit full backfill**
- `contextd index --semantic` → `reconcile_full_inner` → `sync_missing_vectors_for_root` (full scan, batch 256, GC).
- `contextd index` without flag = fast structural only.

**4. Changed-files-only incremental**
- Uses `StructuralBuildOutcome { changed_files, deleted_files }` from `build_with_delta()` (sorted, Ollama-free).
- `sync_changed_files_vectors` loads chunks per changed file only, no whole-repo scan.

## Gates at 048b252 (final HEAD)

```
cargo clippy --workspace --all-targets --all-features -- -D warnings  → PASS (9.63s)
cargo test --workspace                                  → PASS (180s, 12 test_retrieval incl. 20x determinism)
cargo fmt --check                                       → PASS
cargo build --release -p contextd                       → PASS
```

Specific:
```
cargo test -p context-index r5c_j_partial_failure_and_retry -- --nocapture  → PASS (8/8)
cargo test -p contextd incremental_one_file_change_only_that_file -- --nocapture → PASS (was FAIL 0 vs 1 at 7b90c2c, now 1)
```

## Benchmark (m1-v1.2, smoke, 18 Qs, top_n=5)

**Disabled** (`CONTEXTD_SEMANTIC_ENABLED=0`):
```
Hit@1 0.556 Hit@3 0.611 Hit@5 0.667 MRR 0.597  P50 2494 P95 13237
conceptual 0/4
```

**Enabled retry with vectors ready** (40295 django / 3415 nestjs / 3319 ripgrep, batch 256, timeout 600):
```
Hit@1 0.556 Hit@3 0.611 Hit@5 0.667 MRR 0.597  P50 2798 P95 11680
conceptual 0/4 -> SEMANTIC_RETRIEVAL_FAILURE (all 4, no RRF/authority tuning per spec)
```

No ranking/benchmark contamination (`git diff main -- crates/...` shows 0 django/nestjs/ripgrep).

## Status truthfulness

After explicit `index --semantic`:
```
eligible 40295 missing 0 ready true  (django)
eligible 3415 missing 0 ready true
```
Cold search: `eligible 0 or missing>0` → `ready false`, `missing 2585`, vectors 0, lexical works.

## Verdict

**MERGE PR #10 and freeze R5.1-C infrastructure.**

Conceptual 0/4 is expected for this PR — infrastructure works, `all-minilm` + chunk representation does not retrieve. Next phase **R5.1-C2 Semantic Retrieval Quality** will inspect why correct chunks are outside top-10.

Snyk check: success (only check exposed by GitHub for this HEAD).
