### PR TITLE
R5.1-E1: Add performance telemetry and remove duplicate repository discovery

### DIFF
--- a/bench/adapters/context_engine.py
+++ b/bench/adapters/context_engine.py
@@ -310,6 +310,13 @@ class ContextEngineAdapter(BenchmarkAdapter):
         if "candidate_tokens" in stats:
             candidate_tokens = stats["candidate_tokens"]
 
+        # infer cache hit
+        cache_hit_inferred = cache_hit
+        if cache_hit_inferred is None and semantic_embed_ms is not None and semantic_search_ms is not None:
+            if semantic_embed_ms == 0 and vector_scanned is not None and vector_scanned > 0:
+                cache_hit_inferred = True
+            elif semantic_embed_ms is not None and semantic_embed_ms > 0:
+                cache_hit_inferred = False
         # retrievers: append wall vs internal for visibility
         retrievers = list(retrievers) if isinstance(retrievers, list) else []
         retrievers.append(f"wall:{wall_ms}")
@@ -347,6 +354,8 @@ class ContextEngineAdapter(BenchmarkAdapter):
             generation=int(generation) if generation is not None else None,
             dirty_file_count=int(dirty) if dirty is not None else None,
             vector_count_scanned=int(vector_scanned) if vector_scanned is not None else None,
-            cache_hit=bool(cache_hit) if cache_hit is not None else None,
-            raw=data,
+            cache_hit=bool(cache_hit_inferred) if cache_hit_inferred is not None else None,
+            process_pid=None,
+            startup_ms=None,
+            raw={**data, "wall_ms": wall_ms, "internal_ms": internal_ms, "cache_hit_inferred": cache_hit_inferred},
         )

--- a/bench/adapters/context_engine.py
+++ b/bench/adapters/context_engine.py
@@ -1,0 +1,352 @@
+"""Thin real-contextd subprocess adapter for Context Bench v1.
+
+This adapter does NOT reimplement retrieval, ranking, packing, or planning.
+It is a subprocess wrapper over the actual Rust release binary `contextd`:
+
+  cargo build --release -p contextd
+  contextd --root <repo> --json --max-results 5 search "<query>"
+
+It parses real JSON fields (evidence, stats, context) and maps them into
+SearchResult. No fake scores, no whitespace token estimates when real tokens
+exist.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List
+
+from .interface import BenchmarkAdapter, IndexingMetrics, SearchHit, SearchResult
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _resolve_bin() -> Path:
+    env = os.environ.get("CONTEXTD_BIN")
+    if env:
+        p = Path(env)
+        if p.exists():
+            return p
+    # platform-specific
+    if sys.platform == "win32":
+        cand = REPO_ROOT / "target" / "release" / "contextd.exe"
+        if cand.exists():
+            return cand
+        # also check without exe? fallback
+        cand2 = REPO_ROOT / "target" / "release" / "contextd"
+        if cand2.exists():
+            return cand2
+        return cand
+    else:
+        cand = REPO_ROOT / "target" / "release" / "contextd"
+        return cand
+
+
+def _ensure_built() -> Path:
+    bin_path = _resolve_bin()
+    if bin_path.exists():
+        return bin_path
+    # try to build once (outside timing)
+    print(f"[context_engine] binary not found at {bin_path}, building cargo --release -p contextd ...", flush=True)
+    # cargo build --release -p contextd
+    proc = subprocess.run(
+        ["cargo", "build", "--release", "-p", "contextd"],
+        cwd=REPO_ROOT,
+        capture_output=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"cargo build --release -p contextd failed with {proc.returncode}")
+    # re-resolve
+    bin_path = _resolve_bin()
+    if not bin_path.exists():
+        raise RuntimeError(f"contextd binary still not found at {bin_path} after build")
+    return bin_path
+
+
+def _run_json(args: List[str], cwd: Path | None = None, timeout: int = 120) -> dict:
+    # args[0] is bin, rest are args
+    proc = subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="ignore",
+        timeout=timeout,
+    )
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0 and not stdout:
+        raise RuntimeError(f"contextd failed rc={proc.returncode} stderr={stderr[:500]}")
+    # stdout should be JSON
+    # contextd prints pretty JSON; strip any leading non-json?
+    # Find first { or [
+    if not stdout:
+        raise RuntimeError(f"empty stdout rc={proc.returncode} stderr={stderr[:500]}")
+    # Some tracing may leak to stdout? but cli.rs writes tracing to stderr, so stdout is pure json.
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as e:
+        # try to find json substring
+        s = stdout.find("{")
+        if s != -1:
+            try:
+                return json.loads(stdout[s:])
+            except Exception:
+                pass
+        raise RuntimeError(f"failed to parse contextd JSON: {e} stdout={stdout[:1000]} stderr={stderr[:500]}")
+
+
+class ContextEngineAdapter(BenchmarkAdapter):
+    """Thin real-contextd subprocess adapter."""
+
+    name = "context_engine"
+
+    def __init__(self) -> None:
+        self._bin = _ensure_built()
+
+    def index(self, repo_path: Path) -> IndexingMetrics:
+        """Capture real contextd status for this repo.
+        Indexing is done lazily via reconcile on first search; here we just
+        query status to record filesIndexed/symbols/bm25/vector/semantic.
+        Wall times for cold/warm/one-file are measured separately via searches;
+        here we record initial_wall as status call time and mark others unavailable
+        with honest labelling (cold first-search wall time measured in separate phase).
+        """
+        t0 = time.perf_counter()
+        try:
+            data = _run_json(
+                [str(self._bin), "--root", str(repo_path), "--json", "status"],
+                timeout=30,
+            )
+        except Exception as e:
+            print(f"[context_engine] status failed for {repo_path}: {e}", file=sys.stderr)
+            wall = int((time.perf_counter() - t0) * 1000)
+            return IndexingMetrics(
+                initial_wall_ms=wall,
+                files_indexed=None,
+                symbols=None,
+                bm25_docs=None,
+                vector_count=None,
+                index_disk_bytes=None,
+                unavailable=[
+                    "symbols",
+                    "bm25_docs",
+                    "vector_count",
+                    "index_disk_bytes",
+                    "cpu_ms",
+                    "peak_rss_mb",
+                    "no_change_wall_ms",
+                    "one_file_wall_ms",
+                    "status_error",
+                ],
+            )
+        wall = int((time.perf_counter() - t0) * 1000)
+        # status fields: camelCase
+        files_indexed = data.get("filesIndexed") if "filesIndexed" in data else data.get("files_indexed")
+        symbols = data.get("symbols")
+        bm25_docs = data.get("bm25Documents") if "bm25Documents" in data else data.get("bm25_documents")
+        vector_count = data.get("vectorCount") if "vectorCount" in data else data.get("vector_count")
+        # index disk not exposed via status; leave None
+        # record what is available directly via data
+        unavailable = []
+        if files_indexed is None:
+            unavailable.append("files_indexed")
+        if symbols is None:
+            unavailable.append("symbols")
+        if bm25_docs is None:
+            unavailable.append("bm25_docs")
+        if vector_count is None:
+            unavailable.append("vector_count")
+        unavailable.extend(["index_disk_bytes", "cpu_ms", "peak_rss_mb", "no_change_wall_ms", "one_file_wall_ms"])
+        # store extra status for debugging
+        self._last_status = data
+        return IndexingMetrics(
+            initial_wall_ms=wall,
+            files_indexed=int(files_indexed) if files_indexed is not None else None,
+            symbols=int(symbols) if symbols is not None else None,
+            bm25_docs=int(bm25_docs) if bm25_docs is not None else None,
+            vector_count=int(vector_count) if vector_count is not None else None,
+            index_disk_bytes=None,
+            unavailable=unavailable,
+        )
+
+    def search(self, query: str, repo_path: Path, top_n: int = 5) -> SearchResult:
+        t0 = time.perf_counter()
+        try:
+            data = _run_json(
+                [
+                    str(self._bin),
+                    "--root",
+                    str(repo_path),
+                    "--json",
+                    "--max-results",
+                    str(top_n),
+                    "search",
+                    query,
+                ],
+                timeout=300,
+            )
+        except Exception as e:
+            # surface error but return empty hits so runner records failure honestly
+            print(f"[context_engine] search failed query={query!r} repo={repo_path}: {e}", file=sys.stderr)
+            elapsed = int((time.perf_counter() - t0) * 1000)
+            return SearchResult(
+                query=query,
+                hits=[],
+                candidate_count=0,
+                evidence_count=0,
+                files_returned=0,
+                candidate_tokens=None,
+                packed_tokens=None,
+                retrievers_used=[f"error:{e}"],
+                elapsed_ms=elapsed,
+            )
+
+        # data keys: query, type, evidence[], context, stats{ candidate_count, evidence_count, files_returned, packed_tokens, retrievers, elapsed_ms, exact_ms, structural_ms, bm25_ms, semantic_ms, rank_ms, pack_ms }
+        evidence = data.get("evidence") or []
+        stats = data.get("stats") or {}
+        context_text = data.get("context") or ""
+
+        # Map evidence to SearchHit preserving rank order
+        hits: List[SearchHit] = []
+        for ev in evidence:
+            # file is primary
+            f = ev.get("file") or ev.get("path") or ""
+            f = f.replace("\\", "/")
+            # lines field is "start-end" string or ""
+            line = None
+            lines_str = ev.get("lines") or ""
+            if lines_str and "-" in lines_str:
+                try:
+                    line = int(lines_str.split("-")[0].split(":")[-1])
+                except Exception:
+                    line = None
+            elif lines_str:
+                try:
+                    line = int(lines_str.strip().split(":")[-1])
+                except Exception:
+                    line = None
+            # fallback: ev may have start_line if we change cli to expose it
+            if line is None and ev.get("start_line") is not None:
+                try:
+                    line = int(ev["start_line"])
+                except Exception:
+                    line = None
+            # text snippet: not directly in this custom json (only for other commands uses ev.text), but search custom json omitted text; we can leave None or use symbol
+            text = ev.get("text")
+            # score mapping: use finalScore if available else score
+            score = ev.get("finalScore")
+            if score is None:
+                score = ev.get("score")
+            # provenance
+            prov = ev.get("source") or ev.get("provenance") or ""
+            # attach relation/symbol for debugging but file is ranking key
+            symbol = ev.get("symbol")
+            # combine provenance with relation for visibility
+            rel = ev.get("relation")
+            if rel and prov:
+                prov = f"{prov}:{rel}"
+            elif rel:
+                prov = str(rel)
+            hits.append(
+                SearchHit(
+                    file=f,
+                    score=float(score) if score is not None else None,
+                    line=line,
+                    text=text,
+                    symbol=symbol,
+                    provenance=prov,
+                )
+            )
+            if len(hits) >= top_n:
+                break
+
+        # Stats mapping: handle both camel and snake
+        def g(k_snake, k_camel, default=None):
+            if k_snake in stats:
+                return stats[k_snake]
+            if k_camel in stats:
+                return stats[k_camel]
+            return default
+
+        candidate_count = g("candidate_count", "candidateCount", 0) or 0
+        evidence_count = g("evidence_count", "evidenceCount", len(hits)) or len(hits)
+        files_returned = g("files_returned", "filesReturned", len(set(h.file for h in hits))) or len(set(h.file for h in hits))
+        packed_tokens = g("packed_tokens", "packedTokens", None)
+        # retrievers: list of strings
+        retrievers = stats.get("retrievers") or stats.get("retrievers_used") or []
+        wall_ms = int((time.perf_counter() - t0) * 1000)
+        elapsed_ms = g("elapsed_ms", "elapsedMs", None)
+        # internal is stats elapsed if present, else wall
+        internal_ms = int(elapsed_ms) if elapsed_ms is not None else wall_ms
+        # but keep wall vs internal distinct
+        exact_ms = g("exact_ms", "exactMs", None)
+        structural_ms = g("structural_ms", "structuralMs", None)
+        bm25_ms = g("bm25_ms", "bm25Ms", None)
+        semantic_ms = g("semantic_ms", "semanticMs", None)
+        semantic_embed_ms = g("semantic_embed_ms", "semanticEmbedMs", None)
+        semantic_search_ms = g("semantic_search_ms", "semanticSearchMs", None)
+        rank_ms = g("rank_ms", "rankMs", None)
+        authority_ms = g("authority_ms", "authorityMs", None)
+        fusion_ms = g("fusion_ms", "fusionMs", None)
+        pack_ms = g("pack_ms", "packMs", None)
+        discovery_ms = g("discovery_ms", "discoveryMs", None)
+        reconcile_ms = g("reconcile_ms", "reconcileMs", None)
+        total_ms = g("total_ms", "totalMs", None)
+        generation = g("generation", "generation", None)
+        dirty = g("dirty_file_count", "dirtyFileCount", None)
+        vector_scanned = g("vector_count_scanned", "vectorCountScanned", None)
+        cache_hit = g("cache_hit", "cacheHit", None)
+
+        # candidate_tokens: not exposed by production; leave None honestly
+        candidate_tokens = None
+        # If contextd later exposes it, parse here:
+        if "candidate_tokens" in stats:
+            candidate_tokens = stats["candidate_tokens"]
+
+        # retrievers: append wall vs internal for visibility
+        retrievers = list(retrievers) if isinstance(retrievers, list) else []
+        retrievers.append(f"wall:{wall_ms}")
+        retrievers.append(f"internal:{internal_ms}")
+        if discovery_ms is not None:
+            retrievers.append(f"discovery:{discovery_ms}")
+        if reconcile_ms is not None:
+            retrievers.append(f"reconcile:{reconcile_ms}")
+
+        return SearchResult(
+            query=query,
+            hits=hits,
+            candidate_count=int(candidate_count) if candidate_count is not None else 0,
+            evidence_count=int(evidence_count) if evidence_count is not None else len(hits),
+            files_returned=int(files_returned) if files_returned is not None else len(set(h.file for h in hits)),
+            candidate_tokens=candidate_tokens,
+            packed_tokens=int(packed_tokens) if packed_tokens is not None else None,
+            retrievers_used=retrievers,
+            elapsed_ms=int(internal_ms),
+            wall_ms=wall_ms,
+            internal_ms=int(internal_ms),
+            exact_ms=int(exact_ms) if exact_ms is not None else None,
+            structural_ms=int(structural_ms) if structural_ms is not None else None,
+            bm25_ms=int(bm25_ms) if bm25_ms is not None else None,
+            semantic_ms=int(semantic_ms) if semantic_ms is not None else None,
+            rank_ms=int(rank_ms) if rank_ms is not None else (int(authority_ms) if authority_ms is not None else None),
+            pack_ms=int(pack_ms) if pack_ms is not None else None,
+            total_ms=int(total_ms) if total_ms is not None else None,
+            discovery_ms=int(discovery_ms) if discovery_ms is not None else None,
+            reconcile_ms=int(reconcile_ms) if reconcile_ms is not None else None,
+            semantic_embed_ms=int(semantic_embed_ms) if semantic_embed_ms is not None else None,
+            semantic_search_ms=int(semantic_search_ms) if semantic_search_ms is not None else None,
+            fusion_ms=int(fusion_ms) if fusion_ms is not None else None,
+            authority_ms=int(authority_ms) if authority_ms is not None else (int(rank_ms) if rank_ms is not None else None),
+            generation=int(generation) if generation is not None else None,
+            dirty_file_count=int(dirty) if dirty is not None else None,
+            vector_count_scanned=int(vector_scanned) if vector_scanned is not None else None,
+            cache_hit=bool(cache_hit) if cache_hit is not None else None,
+            raw=data,
+        )

--- a/bench/adapters/context_engine_hot.py
+++ b/bench/adapters/context_engine_hot.py
@@ -73,6 +73,7 @@ class _McpClient:
     def __init__(self, repo_path: Path):
         self.repo_path = repo_path
         self.bin = _ensure_built()
+        t_start = time.perf_counter()
         self.proc = subprocess.Popen(
             [str(self.bin), "--root", str(repo_path), "mcp"],
             stdin=subprocess.PIPE,
@@ -89,6 +90,9 @@ class _McpClient:
         self._reader_thread = threading.Thread(target=self._reader, daemon=True)
         self._reader_thread.start()
         self._initialize()
+        self.startup_ms = int((time.perf_counter() - t_start) * 1000)
+        self.os_pid = self.proc.pid
+        self.contextd_pid = self.os_pid
 
     def _send(self, obj: dict):
         line = json.dumps(obj, ensure_ascii=False)
@@ -396,22 +400,38 @@ class ContextEngineHotAdapter(BenchmarkAdapter):
         vector_scanned = g("vector_count_scanned", "vectorCountScanned", None)
 
         # hot must report both wall and internal
-        # we store wall in retrievers for visibility and keep elapsed_ms as internal per spec? But spec says report BOTH.
-        # So we put internal in elapsed_ms, and wall in separate field via retrievers and also use wall_ms for timing.
-        # For compatibility, we return SearchResult with elapsed_ms = internal, but we stash wall in retrievers and also raw.
+        # wall is adapter-measured per query (excludes startup), internal is engine pipeline
+        # transport = wall - total_ms (total includes discovery+reconcile+pipeline)
+        total_for_transport = total_ms if total_ms is not None else internal_ms
+        transport = wall_ms - total_for_transport if total_for_transport is not None else None
         retrievers = list(retrievers) if isinstance(retrievers, list) else []
         # append wall vs internal for debugging
         retrievers.append(f"wall:{wall_ms}")
         retrievers.append(f"internal:{internal_ms}")
+        if total_ms is not None:
+            retrievers.append(f"total:{total_ms}")
+        if transport is not None:
+            retrievers.append(f"transport:{transport}")
         if discovery_ms is not None:
             retrievers.append(f"discovery:{discovery_ms}")
         if reconcile_ms is not None:
             retrievers.append(f"reconcile:{reconcile_ms}")
+        # PID diagnostic
+        pid_for_query = client.contextd_pid
+        startup_for_query = client.startup_ms
 
         # SearchResult currently has fields for stage timings, we map them
         # It does not have discovery/reconcile fields yet; we will extend it via raw and also via new fields if present
         from .interface import SearchResult as SR
 
+        # determine cache hit: if semantic ran and embed 0, likely cache hit
+        cache_hit_val = None
+        if semantic_embed_ms is not None and semantic_search_ms is not None:
+            # if embed 0 but search >0, we had cache hit (or semantic skipped)
+            if semantic_embed_ms == 0 and vector_scanned is not None and vector_scanned > 0:
+                cache_hit_val = True
+            elif semantic_embed_ms is not None and semantic_embed_ms > 0:
+                cache_hit_val = False
         res = SR(
             query=query,
             hits=hits,
@@ -440,10 +460,16 @@ class ContextEngineHotAdapter(BenchmarkAdapter):
             generation=int(generation) if generation is not None else None,
             dirty_file_count=int(dirty) if dirty is not None else None,
             vector_count_scanned=int(vector_scanned) if vector_scanned is not None else None,
-            cache_hit=None,
+            cache_hit=cache_hit_val,
+            process_pid=pid_for_query,
+            startup_ms=startup_for_query,
             raw={
                 "wall_ms": wall_ms,
                 "internal_ms": internal_ms,
+                "total_ms": total_ms,
+                "transport_ms": transport,
+                "startup_ms": startup_for_query,
+                "process_pid": pid_for_query,
                 "stats": stats,
                 "data": data,
                 "discovery_ms": discovery_ms,
@@ -456,6 +482,7 @@ class ContextEngineHotAdapter(BenchmarkAdapter):
                 "generation": generation,
                 "dirty_file_count": dirty,
                 "vector_count_scanned": vector_scanned,
+                "cache_hit": cache_hit_val,
             },
         )
         return res

--- a/bench/adapters/context_engine_hot.py
+++ b/bench/adapters/context_engine_hot.py
@@ -1,0 +1,469 @@
+"""Persistent MCP adapter for hot benchmark (steady-state).
+
+Keeps one contextd MCP process per repo alive across N queries.
+Measures both wall clock (adapter) and internal engine elapsed (from stats)
+so MCP transport overhead is distinguishable.
+
+Protocol is minimal JSON-RPC 2.0 over stdio (line-delimited) matching rmcp's stdio:
+  -> initialize
+  <- result
+  -> notifications/initialized
+  -> tools/call for context_search
+  <- result
+
+No benchmark-specific production logic; uses existing MCP service.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import threading
+import queue
+from pathlib import Path
+from typing import Dict, Optional
+
+from .interface import BenchmarkAdapter, IndexingMetrics, SearchHit, SearchResult
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _resolve_bin() -> Path:
+    env = os.environ.get("CONTEXTD_BIN")
+    if env:
+        p = Path(env)
+        if p.exists():
+            return p
+    if sys.platform == "win32":
+        cand = REPO_ROOT / "target" / "release" / "contextd.exe"
+        if cand.exists():
+            return cand
+        cand2 = REPO_ROOT / "target" / "release" / "contextd"
+        if cand2.exists():
+            return cand2
+        return cand
+    else:
+        cand = REPO_ROOT / "target" / "release" / "contextd"
+        return cand
+
+
+def _ensure_built() -> Path:
+    bin_path = _resolve_bin()
+    if bin_path.exists():
+        return bin_path
+    print(f"[hot] building contextd --release ...", flush=True)
+    proc = subprocess.run(["cargo", "build", "--release", "-p", "contextd"], cwd=REPO_ROOT)
+    if proc.returncode != 0:
+        raise RuntimeError("cargo build failed")
+    bin_path = _resolve_bin()
+    if not bin_path.exists():
+        raise RuntimeError(f"bin not found {bin_path}")
+    return bin_path
+
+
+class _McpClient:
+    """Minimal JSON-RPC 2.0 client over stdio, line-delimited.
+
+    pty-safe: runs reader thread, queue for responses keyed by id.
+    """
+
+    def __init__(self, repo_path: Path):
+        self.repo_path = repo_path
+        self.bin = _ensure_built()
+        self.proc = subprocess.Popen(
+            [str(self.bin), "--root", str(repo_path), "mcp"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="ignore",
+            bufsize=1,  # line buffered
+        )
+        self._next_id = 1
+        self._pending: Dict[int, queue.Queue] = {}
+        self._pending_lock = threading.Lock()
+        self._reader_thread = threading.Thread(target=self._reader, daemon=True)
+        self._reader_thread.start()
+        self._initialize()
+
+    def _send(self, obj: dict):
+        line = json.dumps(obj, ensure_ascii=False)
+        # rmcp expects one JSON per line
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(line + "\n")
+        self.proc.stdin.flush()
+
+    def _reader(self):
+        assert self.proc.stdout is not None
+        for line in iter(self.proc.stdout.readline, ""):
+            if not line:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except Exception:
+                # ignore non-json stderr? but stdout should be pure json
+                continue
+            # response has id
+            if "id" in msg:
+                mid = msg["id"]
+                with self._pending_lock:
+                    q = self._pending.get(mid)
+                if q is not None:
+                    q.put(msg)
+                # also handle notifications without id? ignore
+            else:
+                # notification from server (e.g., progress) - ignore
+                pass
+
+    def _request(self, method: str, params=None, timeout: int = 30) -> dict:
+        mid = self._next_id
+        self._next_id += 1
+        q: queue.Queue = queue.Queue()
+        with self._pending_lock:
+            self._pending[mid] = q
+        req = {"jsonrpc": "2.0", "id": mid, "method": method}
+        if params is not None:
+            req["params"] = params
+        self._send(req)
+        try:
+            resp = q.get(timeout=timeout)
+        except queue.Empty:
+            raise TimeoutError(f"mcp request {method} timeout")
+        finally:
+            with self._pending_lock:
+                self._pending.pop(mid, None)
+        if "error" in resp:
+            raise RuntimeError(f"mcp error {resp['error']}")
+        return resp.get("result", resp)
+
+    def _notify(self, method: str, params=None):
+        obj = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            obj["params"] = params
+        self._send(obj)
+
+    def _initialize(self):
+        # rmcp expects protocolVersion 2024-11-05
+        try:
+            self._request(
+                "initialize",
+                {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "bench-hot", "version": "0.1.0"},
+                },
+                timeout=10,
+            )
+        except Exception as e:
+            # try fallback with 2025 version?
+            print(f"[hot] initialize failed: {e}", file=sys.stderr)
+            raise
+        # send initialized notification (no id)
+        self._notify("notifications/initialized", {})
+        # small pause to let server settle
+        time.sleep(0.15)
+
+    def call_tool(self, name: str, arguments: dict, timeout: int = 60) -> dict:
+        params = {"name": name, "arguments": arguments}
+        result = self._request("tools/call", params, timeout=timeout)
+        # result is CallToolResult: {content: [{type:"text", text:"{...}"}], isError?}
+        content = result.get("content") or []
+        text = ""
+        for c in content:
+            if isinstance(c, dict):
+                if c.get("type") == "text" and "text" in c:
+                    text += c["text"] + "\n"
+                elif "text" in c:
+                    text += c["text"] + "\n"
+        text = text.strip()
+        if not text:
+            # some servers return content as string?
+            return result
+        try:
+            return json.loads(text)
+        except Exception:
+            # if text is not json, return raw
+            return {"raw_text": text, "result": result}
+
+    def status(self, timeout: int = 15) -> dict:
+        return self.call_tool("context_status", {}, timeout=timeout)
+
+    def search(self, query: str, max_results: int = 5, budget_tokens: int = 10000, timeout: int = 180) -> dict:
+        return self.call_tool(
+            "context_search", {"query": query, "maxResults": max_results, "budgetTokens": budget_tokens}, timeout=timeout
+        )
+
+    def close(self):
+        try:
+            if self.proc.stdin:
+                self.proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        except Exception:
+            pass
+
+
+class ContextEngineHotAdapter(BenchmarkAdapter):
+    """Hot persistent adapter via MCP."""
+
+    name = "context_engine_hot"
+
+    def __init__(self) -> None:
+        self._bin = _ensure_built()
+        self._clients: Dict[str, _McpClient] = {}
+
+    def _client_for(self, repo_path: Path) -> _McpClient:
+        key = str(repo_path.resolve())
+        if key not in self._clients:
+            self._clients[key] = _McpClient(repo_path)
+        return self._clients[key]
+
+    def index(self, repo_path: Path) -> IndexingMetrics:
+        t0 = time.perf_counter()
+        try:
+            client = self._client_for(repo_path)
+            data = client.status()
+            # data is parsed json from tool result: contains fields like pid, project_root, files_indexed etc
+            # Map similar to context_engine.py
+            # status fields are camelCase per service.rs StatusReport
+            wall = int((time.perf_counter() - t0) * 1000)
+            # data may contain stats directly
+            files_indexed = data.get("filesIndexed") if "filesIndexed" in data else data.get("files_indexed")
+            symbols = data.get("symbols")
+            bm25_docs = data.get("bm25Documents") if "bm25Documents" in data else data.get("bm25_documents")
+            vector_count = data.get("vectorCount") if "vectorCount" in data else data.get("vector_count")
+            unavailable = []
+            if files_indexed is None:
+                unavailable.append("files_indexed")
+            if symbols is None:
+                unavailable.append("symbols")
+            if bm25_docs is None:
+                unavailable.append("bm25_docs")
+            if vector_count is None:
+                unavailable.append("vector_count")
+            unavailable.extend(["index_disk_bytes", "cpu_ms", "peak_rss_mb", "no_change_wall_ms", "one_file_wall_ms"])
+            self._last_status = data
+            return IndexingMetrics(
+                initial_wall_ms=wall,
+                files_indexed=int(files_indexed) if files_indexed is not None else None,
+                symbols=int(symbols) if symbols is not None else None,
+                bm25_docs=int(bm25_docs) if bm25_docs is not None else None,
+                vector_count=int(vector_count) if vector_count is not None else None,
+                index_disk_bytes=None,
+                unavailable=unavailable,
+            )
+        except Exception as e:
+            print(f"[hot] status failed for {repo_path}: {e}", file=sys.stderr)
+            wall = int((time.perf_counter() - t0) * 1000)
+            return IndexingMetrics(
+                initial_wall_ms=wall,
+                files_indexed=None,
+                symbols=None,
+                bm25_docs=None,
+                vector_count=None,
+                index_disk_bytes=None,
+                unavailable=["symbols", "bm25_docs", "vector_count", "index_disk_bytes", "cpu_ms", "peak_rss_mb", "no_change_wall_ms", "one_file_wall_ms", "status_error"],
+            )
+
+    def search(self, query: str, repo_path: Path, top_n: int = 5) -> SearchResult:
+        # wall clock for adapter
+        t_wall0 = time.perf_counter()
+        try:
+            client = self._client_for(repo_path)
+            data = client.search(query, max_results=top_n, timeout=180)
+        except Exception as e:
+            print(f"[hot] search failed query={query!r} repo={repo_path}: {e}", file=sys.stderr)
+            wall_ms = int((time.perf_counter() - t_wall0) * 1000)
+            return SearchResult(
+                query=query,
+                hits=[],
+                candidate_count=0,
+                evidence_count=0,
+                files_returned=0,
+                candidate_tokens=None,
+                packed_tokens=None,
+                retrievers_used=[f"error:{e}"],
+                elapsed_ms=wall_ms,
+            )
+        wall_ms = int((time.perf_counter() - t_wall0) * 1000)
+        # data is parsed from MCP: keys query, type, evidence[], context, stats{}
+        evidence = data.get("evidence") or []
+        # MCP hot now returns stats as full object via serde (includes total_ms etc)
+        # It may be under "stats" or directly; data has "stats"
+        stats = data.get("stats") or {}
+        # If stats is not dict (maybe raw), try to find
+        if not isinstance(stats, dict):
+            stats = {}
+        hits = []
+        for ev in evidence:
+            f = ev.get("file") or ev.get("path") or ""
+            f = f.replace("\\", "/")
+            # lines field "start-end" or ""
+            line = None
+            lines_str = ev.get("lines") or ""
+            if lines_str and "-" in lines_str:
+                try:
+                    line = int(lines_str.split("-")[0].split(":")[-1])
+                except Exception:
+                    line = None
+            elif lines_str:
+                try:
+                    line = int(lines_str.strip().split(":")[-1])
+                except Exception:
+                    line = None
+            if line is None and ev.get("start_line") is not None:
+                try:
+                    line = int(ev["start_line"])
+                except Exception:
+                    line = None
+            text = ev.get("text")
+            score = ev.get("finalScore")
+            if score is None:
+                score = ev.get("score")
+            prov = ev.get("source") or ev.get("provenance") or ""
+            symbol = ev.get("symbol")
+            rel = ev.get("relation")
+            if rel and prov:
+                prov = f"{prov}:{rel}"
+            elif rel:
+                prov = str(rel)
+            from .interface import SearchHit
+
+            hits.append(
+                SearchHit(
+                    file=f,
+                    score=float(score) if score is not None else None,
+                    line=line,
+                    text=text,
+                    symbol=symbol,
+                    provenance=prov,
+                )
+            )
+            if len(hits) >= top_n:
+                break
+
+        def g(k_snake, k_camel, default=None):
+            if k_snake in stats:
+                return stats[k_snake]
+            if k_camel in stats:
+                return stats[k_camel]
+            return default
+
+        candidate_count = g("candidate_count", "candidateCount", 0) or 0
+        evidence_count = g("evidence_count", "evidenceCount", len(hits)) or len(hits)
+        files_returned = g("files_returned", "filesReturned", len(set(h.file for h in hits))) or len(set(h.file for h in hits))
+        packed_tokens = g("packed_tokens", "packedTokens", None)
+        retrievers = stats.get("retrievers") or stats.get("retrievers_used") or []
+        # internal elapsed is stats elapsed_ms / total_ms
+        internal_ms = g("elapsed_ms", "elapsedMs", None)
+        if internal_ms is None:
+            internal_ms = g("total_ms", "totalMs", None)
+        # if still None, fallback to wall
+        if internal_ms is None:
+            internal_ms = wall_ms
+        else:
+            internal_ms = int(internal_ms)
+
+        # stage timings
+        exact_ms = g("exact_ms", "exactMs", None)
+        structural_ms = g("structural_ms", "structuralMs", None)
+        bm25_ms = g("bm25_ms", "bm25Ms", None)
+        semantic_ms = g("semantic_ms", "semanticMs", None)
+        semantic_embed_ms = g("semantic_embed_ms", "semanticEmbedMs", None)
+        semantic_search_ms = g("semantic_search_ms", "semanticSearchMs", None)
+        rank_ms = g("rank_ms", "rankMs", None)
+        authority_ms = g("authority_ms", "authorityMs", None)
+        fusion_ms = g("fusion_ms", "fusionMs", None)
+        pack_ms = g("pack_ms", "packMs", None)
+        discovery_ms = g("discovery_ms", "discoveryMs", None)
+        reconcile_ms = g("reconcile_ms", "reconcileMs", None)
+        total_ms = g("total_ms", "totalMs", None)
+        generation = g("generation", "generation", None)
+        dirty = g("dirty_file_count", "dirtyFileCount", None)
+        vector_scanned = g("vector_count_scanned", "vectorCountScanned", None)
+
+        # hot must report both wall and internal
+        # we store wall in retrievers for visibility and keep elapsed_ms as internal per spec? But spec says report BOTH.
+        # So we put internal in elapsed_ms, and wall in separate field via retrievers and also use wall_ms for timing.
+        # For compatibility, we return SearchResult with elapsed_ms = internal, but we stash wall in retrievers and also raw.
+        retrievers = list(retrievers) if isinstance(retrievers, list) else []
+        # append wall vs internal for debugging
+        retrievers.append(f"wall:{wall_ms}")
+        retrievers.append(f"internal:{internal_ms}")
+        if discovery_ms is not None:
+            retrievers.append(f"discovery:{discovery_ms}")
+        if reconcile_ms is not None:
+            retrievers.append(f"reconcile:{reconcile_ms}")
+
+        # SearchResult currently has fields for stage timings, we map them
+        # It does not have discovery/reconcile fields yet; we will extend it via raw and also via new fields if present
+        from .interface import SearchResult as SR
+
+        res = SR(
+            query=query,
+            hits=hits,
+            candidate_count=int(candidate_count) if candidate_count is not None else 0,
+            evidence_count=int(evidence_count) if evidence_count is not None else len(hits),
+            files_returned=int(files_returned) if files_returned is not None else len(set(h.file for h in hits)),
+            candidate_tokens=None,
+            packed_tokens=int(packed_tokens) if packed_tokens is not None else None,
+            retrievers_used=retrievers,
+            elapsed_ms=int(internal_ms) if internal_ms is not None else wall_ms,
+            wall_ms=wall_ms,
+            internal_ms=int(internal_ms) if internal_ms is not None else wall_ms,
+            exact_ms=int(exact_ms) if exact_ms is not None else None,
+            structural_ms=int(structural_ms) if structural_ms is not None else None,
+            bm25_ms=int(bm25_ms) if bm25_ms is not None else None,
+            semantic_ms=int(semantic_ms) if semantic_ms is not None else None,
+            rank_ms=int(rank_ms) if rank_ms is not None else (int(authority_ms) if authority_ms is not None else None),
+            pack_ms=int(pack_ms) if pack_ms is not None else None,
+            total_ms=int(total_ms) if total_ms is not None else None,
+            discovery_ms=int(discovery_ms) if discovery_ms is not None else None,
+            reconcile_ms=int(reconcile_ms) if reconcile_ms is not None else None,
+            semantic_embed_ms=int(semantic_embed_ms) if semantic_embed_ms is not None else None,
+            semantic_search_ms=int(semantic_search_ms) if semantic_search_ms is not None else None,
+            fusion_ms=int(fusion_ms) if fusion_ms is not None else None,
+            authority_ms=int(authority_ms) if authority_ms is not None else (int(rank_ms) if rank_ms is not None else None),
+            generation=int(generation) if generation is not None else None,
+            dirty_file_count=int(dirty) if dirty is not None else None,
+            vector_count_scanned=int(vector_scanned) if vector_scanned is not None else None,
+            cache_hit=None,
+            raw={
+                "wall_ms": wall_ms,
+                "internal_ms": internal_ms,
+                "stats": stats,
+                "data": data,
+                "discovery_ms": discovery_ms,
+                "reconcile_ms": reconcile_ms,
+                "total_ms": total_ms,
+                "semantic_embed_ms": semantic_embed_ms,
+                "semantic_search_ms": semantic_search_ms,
+                "fusion_ms": fusion_ms,
+                "authority_ms": authority_ms,
+                "generation": generation,
+                "dirty_file_count": dirty,
+                "vector_count_scanned": vector_scanned,
+            },
+        )
+        return res
+
+    def close(self):
+        for c in list(self._clients.values()):
+            try:
+                c.close()
+            except Exception:
+                pass
+        self._clients.clear()

--- a/bench/adapters/interface.py
+++ b/bench/adapters/interface.py
@@ -61,6 +61,8 @@ class SearchResult:
     dirty_file_count: Optional[int] = None
     vector_count_scanned: Optional[int] = None
     cache_hit: Optional[bool] = None
+    process_pid: Optional[int] = None
+    startup_ms: Optional[int] = None
     # Raw for debugging
     raw: Optional[Dict] = None
 

--- a/bench/adapters/interface.py
+++ b/bench/adapters/interface.py
@@ -1,0 +1,124 @@
+"""Adapter interface for Context Bench v1.
+
+Design goals:
+- Lean, stdlib-only types for harness portability.
+- Supports sync and async implementations (run via asyncio.to_thread if needed).
+- Future adapters (OCI, Codebase-Memory-MCP, Serena) implement the same contract
+  without runner restructuring.
+
+Do NOT add benchmark-aware logic here.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class SearchHit:
+    file: str  # relative POSIX from repo root
+    score: Optional[float] = None
+    line: Optional[int] = None
+    text: Optional[str] = None
+    symbol: Optional[str] = None
+    provenance: Optional[str] = None  # e.g. "rg:exact", "context_engine:exact"
+
+
+@dataclass
+class SearchResult:
+    query: str
+    hits: List[SearchHit] = field(default_factory=list)
+    # Core retrieval metrics (per query)
+    candidate_count: int = 0
+    evidence_count: int = 0
+    files_returned: int = 0
+    candidate_tokens: Optional[int] = None
+    packed_tokens: Optional[int] = None
+    retrievers_used: List[str] = field(default_factory=list)
+    elapsed_ms: int = 0
+    # Wall vs internal (hot must report both)
+    wall_ms: Optional[int] = None
+    internal_ms: Optional[int] = None
+    # Per-stage timings when exposed (Context Engine only)
+    exact_ms: Optional[int] = None
+    structural_ms: Optional[int] = None
+    bm25_ms: Optional[int] = None
+    semantic_ms: Optional[int] = None
+    rank_ms: Optional[int] = None
+    pack_ms: Optional[int] = None
+    # E1 precise stage telemetry (Option/null when not measurable)
+    total_ms: Optional[int] = None
+    discovery_ms: Optional[int] = None
+    reconcile_ms: Optional[int] = None
+    semantic_embed_ms: Optional[int] = None
+    semantic_search_ms: Optional[int] = None
+    fusion_ms: Optional[int] = None
+    authority_ms: Optional[int] = None
+    generation: Optional[int] = None
+    dirty_file_count: Optional[int] = None
+    vector_count_scanned: Optional[int] = None
+    cache_hit: Optional[bool] = None
+    # Raw for debugging
+    raw: Optional[Dict] = None
+
+
+@dataclass
+class IndexingMetrics:
+    # wall time in ms
+    initial_wall_ms: Optional[int] = None
+    no_change_wall_ms: Optional[int] = None
+    one_file_wall_ms: Optional[int] = None
+    # resource
+    cpu_ms: Optional[int] = None
+    peak_rss_mb: Optional[int] = None
+    index_disk_bytes: Optional[int] = None
+    # counts
+    files_indexed: Optional[int] = None
+    symbols: Optional[int] = None
+    bm25_docs: Optional[int] = None
+    vector_count: Optional[int] = None
+    # delta
+    affected_structural_updates: Optional[int] = None
+    index_size_delta_bytes: Optional[int] = None
+    # markers
+    unavailable: List[str] = field(default_factory=list)
+
+
+class BenchmarkAdapter(abc.ABC):
+    """Contract every bench adapter must satisfy.
+
+    Implementations must be:
+    - deterministic given repo_path + query + top_n
+    - isolated per repo (no cross-repo state)
+    - side-effect free for search (index is separate)
+    """
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Stable adapter key, e.g. 'context_engine', 'rg_baseline'."""
+        ...
+
+    @abc.abstractmethod
+    def index(self, repo_path: Path) -> IndexingMetrics:
+        """Build / refresh index for repo_path. Called once per repo run.
+
+        For adapters with no index (rg baseline) return metrics with unavailable
+        markers and files_indexed via simple walk.
+        """
+        ...
+
+    @abc.abstractmethod
+    def search(self, query: str, repo_path: Path, top_n: int = 5) -> SearchResult:
+        """Execute query against repo_path, return top_n hits in ranked order."""
+        ...
+
+    # Optional hook for future adapters that need per-repo setup
+    def warmup(self, repo_path: Path) -> None:
+        pass
+
+    def close(self) -> None:
+        pass

--- a/bench/scripts/run.py
+++ b/bench/scripts/run.py
@@ -505,6 +505,9 @@ def main():
                     "dirty_file_count": getattr(res, "dirty_file_count", None),
                     "vector_count_scanned": getattr(res, "vector_count_scanned", None),
                     "cache_hit": getattr(res, "cache_hit", None),
+                    "process_pid": getattr(res, "process_pid", None),
+                    "startup_ms": getattr(res, "startup_ms", None),
+                    "transport_ms": (getattr(res, "wall_ms", None) - getattr(res, "total_ms", None)) if getattr(res, "wall_ms", None) is not None and getattr(res, "total_ms", None) is not None else None,
                 }
                 with out_path.open("a", encoding="utf-8") as f:
                     f.write(json.dumps(record) + "\n")

--- a/bench/scripts/run.py
+++ b/bench/scripts/run.py
@@ -51,6 +51,24 @@ if ContextEngineHotAdapter is not None:
     ADAPTERS["context_engine_hot"] = ContextEngineHotAdapter
 
 
+def _timing_record(cold_res, warm_res, one_res, neutral_query="Model", had_index_before=True, adapter="context_engine", repo="test", profile="official"):
+    return {
+        "type": "timing",
+        "adapter": adapter,
+        "repo": repo,
+        "profile": profile,
+        "neutral_query": neutral_query,
+        "had_index_before": had_index_before,
+        "label": "cold first-search wall time (not pure index time)",
+        "cold_wall_ms": getattr(cold_res, "wall_ms", None),
+        "cold_internal_ms": getattr(cold_res, "internal_ms", None),
+        "warm_wall_ms": getattr(warm_res, "wall_ms", None),
+        "warm_internal_ms": getattr(warm_res, "internal_ms", None),
+        "one_file_wall_ms": getattr(one_res, "wall_ms", None),
+        "one_file_internal_ms": getattr(one_res, "internal_ms", None),
+    }
+
+
 def load_questions():
     qs = []
     for p in QUESTIONS_DIR.glob("*.jsonl"):
@@ -229,9 +247,10 @@ def main():
                   "!sample/01-cats-app/src/main.ts\n",
     }
     for repo_name in list(by_repo.keys()):
-        repo_path = REPO_ROOT / "bench" / "repos" / repo_name
-        if not repo_path.exists():
+        entry = repo_map.get(repo_name)
+        if entry is None:
             continue
+        repo_path = ensure_repo(repo_name, entry)
         ignore_path = repo_path / ".ignore"
         is_smoke_ignore = ignore_path.exists() and "bench smoke profile" in ignore_path.read_text(encoding="utf-8", errors="ignore")[:500]
         if profile == "official":
@@ -346,7 +365,6 @@ def main():
                     t0 = time.perf_counter()
                     # Use adapter.search which will trigger reconcile+build if index missing
                     cold_res = adapter.search(neutral_q, repo_path, top_n=5)
-                    cold_wall = cold_res.elapsed_ms
                     # restore backups? Actually keep rebuilt index for subsequent warm measurement; remove backups
                     for orig, bak in backups:
                         try:
@@ -357,14 +375,12 @@ def main():
                     # warm measurement (no change)
                     t1 = time.perf_counter()
                     warm_res = adapter.search(neutral_q, repo_path, top_n=5)
-                    warm_wall = warm_res.elapsed_ms
                     # one-file-change: create disposable file, measure, restore exactly
                     tmp_file = repo_path / "__bench_tmp_one_file_change__.txt"
                     try:
                         tmp_file.write_text("bench timing probe", encoding="utf-8")
                         t2 = time.perf_counter()
                         one_res = adapter.search(neutral_q, repo_path, top_n=5)
-                        one_wall = one_res.elapsed_ms
                     finally:
                         try:
                             if tmp_file.exists():
@@ -376,21 +392,10 @@ def main():
                         adapter.search(neutral_q, repo_path, top_n=5)
                     except Exception:
                         pass
-                    timing_rec = {
-                        "type": "timing",
-                        "adapter": adapter.name,
-                        "repo": repo_name,
-                        "profile": profile,
-                        "neutral_query": neutral_q,
-                        "cold_first_search_wall_ms": cold_wall,
-                        "warm_no_change_wall_ms": warm_wall,
-                        "one_file_change_wall_ms": one_wall,
-                        "had_index_before": had_index,
-                        "label": "cold first-search wall time (not pure index time)",
-                    }
+                    timing_rec = _timing_record(cold_res, warm_res, one_res, neutral_query=neutral_q, had_index_before=had_index, adapter=adapter.name, repo=repo_name, profile=profile)
                     with out_path.open("a", encoding="utf-8") as f:
                         f.write(json.dumps(timing_rec) + "\n")
-                    print(f"[{adapter.name}] timing {repo_name}: cold {cold_wall}ms warm {warm_wall}ms one-file {one_wall}ms", flush=True)
+                    print(f"[{adapter.name}] timing {repo_name}: cold {timing_rec['cold_wall_ms']}ms warm {timing_rec['warm_wall_ms']}ms one-file {timing_rec['one_file_wall_ms']}ms", flush=True)
                 except Exception as e:
                     print(f"[{adapter.name}] timing {repo_name} failed: {e}", file=sys.stderr)
             else:
@@ -398,14 +403,11 @@ def main():
                 try:
                     t0 = time.perf_counter()
                     cold_res = adapter.search(neutral_q, repo_path, top_n=5)
-                    cold_wall = cold_res.elapsed_ms
                     warm_res = adapter.search(neutral_q, repo_path, top_n=5)
-                    warm_wall = warm_res.elapsed_ms
                     tmp_file = repo_path / "__bench_tmp_one_file_change__.txt"
                     try:
                         tmp_file.write_text("bench timing probe", encoding="utf-8")
                         one_res = adapter.search(neutral_q, repo_path, top_n=5)
-                        one_wall = one_res.elapsed_ms
                     finally:
                         try:
                             if tmp_file.exists():
@@ -416,21 +418,10 @@ def main():
                         adapter.search(neutral_q, repo_path, top_n=5)
                     except Exception:
                         pass
-                    timing_rec = {
-                        "type": "timing",
-                        "adapter": adapter.name,
-                        "repo": repo_name,
-                        "profile": profile,
-                        "neutral_query": neutral_q,
-                        "cold_first_search_wall_ms": cold_wall,
-                        "warm_no_change_wall_ms": warm_wall,
-                        "one_file_change_wall_ms": one_wall,
-                        "had_index_before": False,
-                        "label": "cold first-search wall time (not pure index time)",
-                    }
+                    timing_rec = _timing_record(cold_res, warm_res, one_res, neutral_query=neutral_q, had_index_before=False, adapter=adapter.name, repo=repo_name, profile=profile)
                     with out_path.open("a", encoding="utf-8") as f:
                         f.write(json.dumps(timing_rec) + "\n")
-                    print(f"[{adapter.name}] timing {repo_name}: cold {cold_wall}ms warm {warm_wall}ms one-file {one_wall}ms (no prior index)", flush=True)
+                    print(f"[{adapter.name}] timing {repo_name}: cold {timing_rec['cold_wall_ms']}ms warm {timing_rec['warm_wall_ms']}ms one-file {timing_rec['one_file_wall_ms']}ms (no prior index)", flush=True)
                 except Exception as e:
                     print(f"[{adapter.name}] timing {repo_name} failed: {e}", file=sys.stderr)
 

--- a/bench/scripts/run.py
+++ b/bench/scripts/run.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Context Bench v1 runner.
+
+Loads bench/manifest.json + bench/questions/*.jsonl, runs each adapter per repo,
+collects retrieval + indexing metrics, writes bench/results/results.jsonl and
+bench/results/summary.md.
+
+Usage:
+  python bench/scripts/run.py --adapters context_engine,rg_baseline --top-n 5
+  python bench/scripts/run.py --repos django,nestjs,ripgrep  # filter for M1
+
+Metrics per query (spec):
+  top1_correct, recall@1/3/5, mrr, rank, candidate_count, evidence_count,
+  files_returned, candidate_tokens, packed_tokens, compression_ratio,
+  retrievers_used, elapsed_ms + per-stage timings when exposed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import sys
+from pathlib import Path
+from collections import defaultdict
+import subprocess
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / "bench" / "manifest.json"
+QUESTIONS_DIR = REPO_ROOT / "bench" / "questions"
+RESULTS_DIR = REPO_ROOT / "bench" / "results"
+RESULTS_JSONL = RESULTS_DIR / "results.jsonl"
+SUMMARY_MD = RESULTS_DIR / "summary.md"
+
+# Import adapters (harness-side, no production import)
+sys.path.insert(0, str(REPO_ROOT / "bench"))
+from adapters.interface import BenchmarkAdapter  # noqa: E402
+from adapters.context_engine import ContextEngineAdapter  # noqa: E402
+from adapters.rg_baseline import RgBaselineAdapter  # noqa: E402
+try:
+    from adapters.context_engine_hot import ContextEngineHotAdapter  # noqa: E402
+except Exception as _e:
+    ContextEngineHotAdapter = None  # type: ignore
+
+ADAPTERS = {
+    "context_engine": ContextEngineAdapter,
+    "rg_baseline": RgBaselineAdapter,
+    # future: oci, codebase_memory, serena (not mandatory in C0)
+}
+if ContextEngineHotAdapter is not None:
+    ADAPTERS["context_engine_hot"] = ContextEngineHotAdapter
+
+
+def load_questions():
+    qs = []
+    for p in QUESTIONS_DIR.glob("*.jsonl"):
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            qs.append(json.loads(line))
+    return qs
+
+
+def compute_retrieval_metrics(expected_files, hits, top_n=5):
+    """hits: list of SearchHit in ranked order (already top_n).
+
+    FILE-LEVEL evaluation: convert evidence into ranked UNIQUE files
+    preserving first occurrence before metrics.
+    Hit@K = binary (any relevant in first K unique files)
+    Recall@K = relevant retrieved / total relevant (fractional)
+    MRR = 1/rank of first relevant unique file
+    """
+    exp_norm = [e.lower().replace("\\", "/") for e in expected_files]
+    # unique expected
+    exp_unique = list(dict.fromkeys(exp_norm))
+    exp_set = set(exp_unique)
+    total_relevant = len(exp_unique) if exp_unique else 1
+
+    # dedupe hits into unique files preserving rank
+    seen = set()
+    unique_files = []
+    unique_hits = []  # SearchHit corresponding to first occurrence per file
+    for h in hits:
+        norm = h.file.lower().replace("\\", "/")
+        if norm not in seen:
+            seen.add(norm)
+            unique_files.append(norm)
+            unique_hits.append(h)
+
+    def matches_expected(hit_file, expected):
+        lf = hit_file.lower()
+        e = expected.lower()
+        return lf == e or lf.endswith("/" + e) or e.endswith("/" + lf) or lf.endswith(e)
+
+    def is_hit_file(hit_file):
+        for e in exp_unique:
+            if matches_expected(hit_file, e):
+                return True
+        return False
+
+    # find rank of first relevant unique file (1-indexed)
+    rank = None
+    for i, uf in enumerate(unique_files, start=1):
+        if is_hit_file(uf):
+            rank = i
+            break
+
+    # Hit@K
+    def hit_at(K):
+        if K <= 0:
+            return 0
+        for uf in unique_files[:K]:
+            if is_hit_file(uf):
+                return 1
+        return 0
+
+    # Recall@K
+    def recall_at(K):
+        if total_relevant == 0:
+            return 0.0
+        retrieved = 0
+        # for each expected, check if it appears in first K unique files
+        for e in exp_unique:
+            for uf in unique_files[:K]:
+                if matches_expected(uf, e):
+                    retrieved += 1
+                    break
+        return retrieved / total_relevant
+
+    top1 = hit_at(1)
+    h1 = hit_at(1)
+    h3 = hit_at(3)
+    h5 = hit_at(5)
+    r1 = recall_at(1)
+    r3 = recall_at(3)
+    r5 = recall_at(5)
+    mrr = 1.0 / rank if rank else 0.0
+    unique_count = len(unique_files)
+
+    return {
+        "top1_correct": top1,
+        "hit_at_1": h1,
+        "hit_at_3": h3,
+        "hit_at_5": h5,
+        "recall_at_1": r1,
+        "recall_at_3": r3,
+        "recall_at_5": r5,
+        "mrr": mrr,
+        "rank": rank,
+        "unique_files": unique_count,
+        "deduplicated_from": len(hits),
+    }
+
+
+def ensure_repo(repo_name, manifest_entry):
+    dest = REPO_ROOT / "bench" / "repos" / repo_name
+    commit = manifest_entry["commit"]
+    if not dest.exists():
+        print(f"{repo_name}: missing, cloning shallow...", flush=True)
+        url = manifest_entry["url"]
+        subprocess.run(["git", "clone", "--no-checkout", "--depth", "1", url, str(dest)], check=True)
+        subprocess.run(["git", "fetch", "--depth", "1", "origin", commit], cwd=dest, check=True)
+        subprocess.run(["git", "checkout", commit], cwd=dest, check=True)
+    else:
+        # verify commit, fetch if needed
+        try:
+            cur = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=dest, text=True).strip()
+            if cur != commit:
+                print(f"{repo_name}: at {cur[:8]} != {commit[:8]}, fetching...", flush=True)
+                subprocess.run(["git", "fetch", "--depth", "1", "origin", commit], cwd=dest, check=True)
+                subprocess.run(["git", "checkout", commit], cwd=dest, check=True)
+        except Exception as e:
+            print(f"{repo_name}: verify failed {e}", file=sys.stderr)
+    return dest
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Context Bench v1 runner")
+    parser.add_argument("--adapters", default="context_engine,rg_baseline", help="comma list of adapter names")
+    parser.add_argument("--top-n", type=int, default=5, help="top_n for search")
+    parser.add_argument("--repos", default=None, help="comma filter for repo names (e.g. django,nestjs,ripgrep)")
+    parser.add_argument("--output", default=str(RESULTS_JSONL), help="output JSONL path")
+    parser.add_argument("--manifest", default=str(MANIFEST), help="manifest path")
+    parser.add_argument("--profile", choices=["smoke", "official"], default="official", help="smoke=fast local with bench-created .ignore (never for public claims), official=exact pinned upstream (default)")
+    args = parser.parse_args()
+    profile = args.profile
+    print(f"Profile: {profile} (smoke=with bench .ignore, official=exact upstream)", flush=True)
+
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    repo_map = {r["name"]: r for r in manifest["repos"]}
+    filter_repos = set(s.strip() for s in args.repos.split(",")) if args.repos else None
+    adapter_names = [a.strip() for a in args.adapters.split(",") if a.strip()]
+
+    questions = load_questions()
+    if filter_repos:
+        questions = [q for q in questions if q["repo"] in filter_repos]
+    print(f"Loaded {len(questions)} questions", flush=True)
+    # group by repo for indexing once
+    by_repo = defaultdict(list)
+    for q in questions:
+        by_repo[q["repo"]].append(q)
+
+    adapters: list[BenchmarkAdapter] = []
+    for name in adapter_names:
+        if name not in ADAPTERS:
+            print(f"unknown adapter {name}, available {list(ADAPTERS)}", file=sys.stderr)
+            sys.exit(2)
+        adapters.append(ADAPTERS[name]())
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = Path(args.output)
+    # clear previous
+    out_path.write_text("", encoding="utf-8")
+    # Profile handling: smoke vs official
+    # SMOKE: bench-created .ignore for fast iteration (NEVER for public claims)
+    # OFFICIAL: exact upstream, respect only repo-native ignores
+    SMOKE_IGNORES = {
+        "django": "# bench smoke profile: ignore large vendor/static for fast local iteration (NEVER for official)\n"
+                  "django/contrib/admin/static/**\n"
+                  "docs/**\n"
+                  "django/contrib/gis/**\n",
+        "nestjs": "# bench smoke profile: fast local with expected files preserved (NEVER for official)\n"
+                  "integration/**\n"
+                  "sample/**\n"
+                  "!sample/01-cats-app/\n"
+                  "!sample/01-cats-app/src/\n"
+                  "!sample/01-cats-app/src/app.module.ts\n"
+                  "!sample/01-cats-app/src/main.ts\n",
+    }
+    for repo_name in list(by_repo.keys()):
+        repo_path = REPO_ROOT / "bench" / "repos" / repo_name
+        if not repo_path.exists():
+            continue
+        ignore_path = repo_path / ".ignore"
+        is_smoke_ignore = ignore_path.exists() and "bench smoke profile" in ignore_path.read_text(encoding="utf-8", errors="ignore")[:500]
+        if profile == "official":
+            if is_smoke_ignore:
+                print(f"[{repo_name}] official profile: removing bench-created .ignore", flush=True)
+                try:
+                    ignore_path.unlink()
+                except Exception as e:
+                    print(f"  failed to remove .ignore: {e}", file=sys.stderr)
+                # also need to clean index that was built with smoke ignores — force rebuild on next search
+                # Remove .context/index to ensure official indexing is not polluted by smoke DB
+                ctx_index = repo_path / ".context" / "index"
+                if ctx_index.exists():
+                    print(f"  cleaning .context/index for official (was smoke)", flush=True)
+                    import shutil as _shutil
+                    try:
+                        _shutil.rmtree(ctx_index)
+                    except Exception as e:
+                        print(f"    rmtree failed: {e}", file=sys.stderr)
+        else:  # smoke
+            if repo_name in SMOKE_IGNORES:
+                if not is_smoke_ignore:
+                    print(f"[{repo_name}] smoke profile: creating bench .ignore", flush=True)
+                    try:
+                        ignore_path.write_text(SMOKE_IGNORES[repo_name], encoding="utf-8")
+                    except Exception as e:
+                        print(f"  failed to write .ignore: {e}", file=sys.stderr)
+                    # clean old official index if exists, so smoke rebuilds with ignores
+                    ctx_index = repo_path / ".context" / "index"
+                    if ctx_index.exists():
+                        import shutil as _shutil
+                        try:
+                            _shutil.rmtree(ctx_index)
+                            print(f"  cleaned .context/index for smoke", flush=True)
+                        except Exception as e:
+                            print(f"    rmtree failed: {e}", file=sys.stderr)
+
+    # Collect indexing metrics per adapter per repo
+    indexing_results = {}
+
+    for adapter in adapters:
+        for repo_name in list(by_repo.keys()):
+            if filter_repos and repo_name not in filter_repos:
+                continue
+            if repo_name not in repo_map:
+                print(f"skip {repo_name}: not in manifest", file=sys.stderr)
+                continue
+            entry = repo_map[repo_name]
+            repo_path = ensure_repo(repo_name, entry)
+            print(f"[{adapter.name}] indexing {repo_name} @ {entry['commit'][:8]}", flush=True)
+            t0 = time.perf_counter()
+            try:
+                idx = adapter.index(repo_path)
+            except Exception as e:
+                print(f"[{adapter.name}] index {repo_name} failed: {e}", file=sys.stderr)
+                idx = None
+            wall = int((time.perf_counter() - t0) * 1000)
+            # store for summary
+            indexing_results[(adapter.name, repo_name)] = idx
+            # also write a synthetic indexing record to results for traceability
+            status_data = getattr(adapter, "_last_status", None) if adapter.name == "context_engine" else None
+            rec = {
+                "type": "indexing",
+                "adapter": adapter.name,
+                "repo": repo_name,
+                "commit": entry["commit"],
+                "profile": profile,
+                "wall_ms": wall,
+                "indexing": idx.__dict__ if idx else None,
+                "status": status_data,
+            }
+            with out_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(rec) + "\n")
+
+    # Additional timing measurements for real contextd: cold first-search, warm, one-file-change
+    # Skip for quick accuracy run; enable via CONTEXT_BENCH_TIMING=1
+    import os as _os
+    _do_timing = _os.environ.get("CONTEXT_BENCH_TIMING") == "1"
+    for adapter in adapters:
+        if not _do_timing or adapter.name != "context_engine":
+            continue
+        for repo_name, qs in by_repo.items():
+            if filter_repos and repo_name not in filter_repos:
+                continue
+            repo_path = REPO_ROOT / "bench" / "repos" / repo_name
+            if not repo_path.exists():
+                continue
+            # neutral query: first question's query for this repo
+            neutral_q = qs[0]["query"] if qs else "Model"
+            # Attempt to capture cold first-search by optionally removing index file (disposable checkout only)
+            # Remove ONLY the bench checkout's contextd index to force cold rebuild, if it exists
+            index_db = repo_path / ".context" / "index" / "structural.db"
+            had_index = index_db.exists()
+            if had_index:
+                try:
+                    # remove index files to force cold rebuild on next search; keep backup via rename if needed
+                    # For C0, we remove only this checkout's index; it will be rebuilt via reconcile
+                    import shutil
+                    idx_dir = repo_path / ".context" / "index"
+                    # save backup list
+                    backups = []
+                    for pat in ["structural.db", "structural.db-wal", "structural.db-shm"]:
+                        p = idx_dir / pat
+                        if p.exists():
+                            bak = p.with_suffix(p.suffix + ".bak_timing")
+                            try:
+                                p.rename(bak)
+                                backups.append((p, bak))
+                            except Exception:
+                                pass
+                    # cold measurement
+                    t0 = time.perf_counter()
+                    # Use adapter.search which will trigger reconcile+build if index missing
+                    cold_res = adapter.search(neutral_q, repo_path, top_n=5)
+                    cold_wall = cold_res.elapsed_ms
+                    # restore backups? Actually keep rebuilt index for subsequent warm measurement; remove backups
+                    for orig, bak in backups:
+                        try:
+                            if bak.exists():
+                                bak.unlink()
+                        except Exception:
+                            pass
+                    # warm measurement (no change)
+                    t1 = time.perf_counter()
+                    warm_res = adapter.search(neutral_q, repo_path, top_n=5)
+                    warm_wall = warm_res.elapsed_ms
+                    # one-file-change: create disposable file, measure, restore exactly
+                    tmp_file = repo_path / "__bench_tmp_one_file_change__.txt"
+                    try:
+                        tmp_file.write_text("bench timing probe", encoding="utf-8")
+                        t2 = time.perf_counter()
+                        one_res = adapter.search(neutral_q, repo_path, top_n=5)
+                        one_wall = one_res.elapsed_ms
+                    finally:
+                        try:
+                            if tmp_file.exists():
+                                tmp_file.unlink()
+                        except Exception:
+                            pass
+                    # reconcile after removal of tmp file to restore state (next search will see deletion)
+                    try:
+                        adapter.search(neutral_q, repo_path, top_n=5)
+                    except Exception:
+                        pass
+                    timing_rec = {
+                        "type": "timing",
+                        "adapter": adapter.name,
+                        "repo": repo_name,
+                        "profile": profile,
+                        "neutral_query": neutral_q,
+                        "cold_first_search_wall_ms": cold_wall,
+                        "warm_no_change_wall_ms": warm_wall,
+                        "one_file_change_wall_ms": one_wall,
+                        "had_index_before": had_index,
+                        "label": "cold first-search wall time (not pure index time)",
+                    }
+                    with out_path.open("a", encoding="utf-8") as f:
+                        f.write(json.dumps(timing_rec) + "\n")
+                    print(f"[{adapter.name}] timing {repo_name}: cold {cold_wall}ms warm {warm_wall}ms one-file {one_wall}ms", flush=True)
+                except Exception as e:
+                    print(f"[{adapter.name}] timing {repo_name} failed: {e}", file=sys.stderr)
+            else:
+                # no index to delete; just measure cold as first search wall, warm as second
+                try:
+                    t0 = time.perf_counter()
+                    cold_res = adapter.search(neutral_q, repo_path, top_n=5)
+                    cold_wall = cold_res.elapsed_ms
+                    warm_res = adapter.search(neutral_q, repo_path, top_n=5)
+                    warm_wall = warm_res.elapsed_ms
+                    tmp_file = repo_path / "__bench_tmp_one_file_change__.txt"
+                    try:
+                        tmp_file.write_text("bench timing probe", encoding="utf-8")
+                        one_res = adapter.search(neutral_q, repo_path, top_n=5)
+                        one_wall = one_res.elapsed_ms
+                    finally:
+                        try:
+                            if tmp_file.exists():
+                                tmp_file.unlink()
+                        except Exception:
+                            pass
+                    try:
+                        adapter.search(neutral_q, repo_path, top_n=5)
+                    except Exception:
+                        pass
+                    timing_rec = {
+                        "type": "timing",
+                        "adapter": adapter.name,
+                        "repo": repo_name,
+                        "profile": profile,
+                        "neutral_query": neutral_q,
+                        "cold_first_search_wall_ms": cold_wall,
+                        "warm_no_change_wall_ms": warm_wall,
+                        "one_file_change_wall_ms": one_wall,
+                        "had_index_before": False,
+                        "label": "cold first-search wall time (not pure index time)",
+                    }
+                    with out_path.open("a", encoding="utf-8") as f:
+                        f.write(json.dumps(timing_rec) + "\n")
+                    print(f"[{adapter.name}] timing {repo_name}: cold {cold_wall}ms warm {warm_wall}ms one-file {one_wall}ms (no prior index)", flush=True)
+                except Exception as e:
+                    print(f"[{adapter.name}] timing {repo_name} failed: {e}", file=sys.stderr)
+
+    # Query runs
+    for adapter in adapters:
+        for repo_name, qs in by_repo.items():
+            if filter_repos and repo_name not in filter_repos:
+                continue
+            entry = repo_map[repo_name]
+            repo_path = REPO_ROOT / "bench" / "repos" / repo_name
+            if not repo_path.exists():
+                print(f"skip {repo_name}: repo not checked out", file=sys.stderr)
+                continue
+            for q in qs:
+                query = q["query"]
+                expected = q["expected_files"]
+                print(f"[{adapter.name}] {q['id']} ({repo_name}/{q['category']})", flush=True)
+                res = adapter.search(query, repo_path, top_n=args.top_n)
+                metrics = compute_retrieval_metrics(expected, res.hits, top_n=args.top_n)
+                # compression ratio: packed / candidate (when both available and candidate >0)
+                comp = None
+                if res.candidate_tokens and res.candidate_tokens > 0 and res.packed_tokens is not None:
+                    comp = round(res.packed_tokens / res.candidate_tokens, 3) if res.candidate_tokens else None
+                record = {
+                    "type": "query",
+                    "id": q["id"],
+                    "repo": q["repo"],
+                    "category": q["category"],
+                    "query": query,
+                    "expected_files": expected,
+                    "expected_symbols": q.get("expected_symbols", []),
+                    "ground_truth_source": q.get("ground_truth_source"),
+                    "adapter": adapter.name,
+                    "commit": entry["commit"],
+                    "profile": profile,
+                    "top_n": args.top_n,
+                    "hits": [{"file": h.file, "score": h.score, "line": h.line, "provenance": h.provenance} for h in res.hits],
+                    "top1_correct": metrics["top1_correct"],
+                    "hit_at_1": metrics["hit_at_1"],
+                    "hit_at_3": metrics["hit_at_3"],
+                    "hit_at_5": metrics["hit_at_5"],
+                    "recall_at_1": metrics["recall_at_1"],
+                    "recall_at_3": metrics["recall_at_3"],
+                    "recall_at_5": metrics["recall_at_5"],
+                    "mrr": metrics["mrr"],
+                    "rank": metrics["rank"],
+                    "unique_files": metrics["unique_files"],
+                    "candidate_count": res.candidate_count,
+                    "evidence_count": res.evidence_count,
+                    "files_returned": res.files_returned,
+                    "candidate_tokens": res.candidate_tokens,
+                    "packed_tokens": res.packed_tokens,
+                    "compression_ratio": comp,
+                    "retrievers_used": res.retrievers_used,
+                    "elapsed_ms": res.elapsed_ms,
+                    "wall_ms": getattr(res, "wall_ms", None),
+                    "internal_ms": getattr(res, "internal_ms", None),
+                    "total_ms": getattr(res, "total_ms", None),
+                    "discovery_ms": getattr(res, "discovery_ms", None),
+                    "reconcile_ms": getattr(res, "reconcile_ms", None),
+                    "exact_ms": res.exact_ms,
+                    "structural_ms": res.structural_ms,
+                    "bm25_ms": res.bm25_ms,
+                    "semantic_ms": res.semantic_ms,
+                    "semantic_embed_ms": getattr(res, "semantic_embed_ms", None),
+                    "semantic_search_ms": getattr(res, "semantic_search_ms", None),
+                    "rank_ms": res.rank_ms,
+                    "authority_ms": getattr(res, "authority_ms", None),
+                    "fusion_ms": getattr(res, "fusion_ms", None),
+                    "pack_ms": res.pack_ms,
+                    "generation": getattr(res, "generation", None),
+                    "dirty_file_count": getattr(res, "dirty_file_count", None),
+                    "vector_count_scanned": getattr(res, "vector_count_scanned", None),
+                    "cache_hit": getattr(res, "cache_hit", None),
+                }
+                with out_path.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps(record) + "\n")
+
+    print(f"Wrote {out_path} ({out_path.stat().st_size} bytes)", flush=True)
+    # Run report generator
+    report_py = REPO_ROOT / "bench" / "scripts" / "report.py"
+    if report_py.exists():
+        print("Generating summary...", flush=True)
+        subprocess.run([sys.executable, str(report_py), "--input", str(out_path)], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/tests/test_run.py
+++ b/bench/tests/test_run.py
@@ -1,0 +1,166 @@
+import sys
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT_FOR_IMPORT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT_FOR_IMPORT))
+sys.path.insert(0, str(REPO_ROOT_FOR_IMPORT / "bench"))
+
+import bench.scripts.run as run
+from adapters.interface import SearchResult, IndexingMetrics
+
+
+class TestTimingHelper(unittest.TestCase):
+    def test_timing_helper_six_fields_elapsed_ignored(self):
+        cold = SearchResult(query="q", elapsed_ms=999, wall_ms=101, internal_ms=22)
+        warm = SearchResult(query="q", elapsed_ms=999, wall_ms=202, internal_ms=33)
+        one = SearchResult(query="q", elapsed_ms=999, wall_ms=303, internal_ms=44)
+        rec = run._timing_record(cold, warm, one, neutral_query="Model", had_index_before=True, adapter="context_engine", repo="test", profile="official")
+        self.assertEqual(rec["cold_wall_ms"], 101)
+        self.assertEqual(rec["cold_internal_ms"], 22)
+        self.assertEqual(rec["warm_wall_ms"], 202)
+        self.assertEqual(rec["warm_internal_ms"], 33)
+        self.assertEqual(rec["one_file_wall_ms"], 303)
+        self.assertEqual(rec["one_file_internal_ms"], 44)
+        for k in ["cold_wall_ms", "cold_internal_ms", "warm_wall_ms", "warm_internal_ms", "one_file_wall_ms", "one_file_internal_ms"]:
+            self.assertIn(k, rec)
+            self.assertNotEqual(rec[k], 999, f"{k} must not be elapsed_ms")
+        self.assertNotIn("cold_first_search_wall_ms", rec)
+        self.assertNotIn("warm_no_change_wall_ms", rec)
+        self.assertNotIn("one_file_change_wall_ms", rec)
+        self.assertEqual(rec["type"], "timing")
+        self.assertEqual(rec["neutral_query"], "Model")
+        self.assertEqual(rec["had_index_before"], True)
+        self.assertEqual(rec["adapter"], "context_engine")
+        self.assertEqual(rec["repo"], "test")
+        self.assertEqual(rec["profile"], "official")
+        # None handling
+        none_cold = SearchResult(query="q", elapsed_ms=999, wall_ms=None, internal_ms=None)
+        none_warm = SearchResult(query="q", elapsed_ms=999, wall_ms=None, internal_ms=None)
+        none_one = SearchResult(query="q", elapsed_ms=999, wall_ms=None, internal_ms=None)
+        rec_none = run._timing_record(none_cold, none_warm, none_one)
+        self.assertIsNone(rec_none["cold_wall_ms"])
+        self.assertIsNone(rec_none["cold_internal_ms"])
+        self.assertIsNone(rec_none["warm_wall_ms"])
+        self.assertIsNone(rec_none["warm_internal_ms"])
+        self.assertIsNone(rec_none["one_file_wall_ms"])
+        self.assertIsNone(rec_none["one_file_internal_ms"])
+
+
+class TestSmokeIntegration(unittest.TestCase):
+    def test_main_smoke_ensure_before_profile_and_official_cleanup(self):
+        expected_django = (
+            "# bench smoke profile: ignore large vendor/static for fast local iteration (NEVER for official)\n"
+            "django/contrib/admin/static/**\n"
+            "docs/**\n"
+            "django/contrib/gis/**\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            src = tmp_path / "src_repo"
+            src.mkdir()
+            subprocess.run(["git", "init"], cwd=src, check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=src, check=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=src, check=True)
+            (src / "README.md").write_text("# test\n", encoding="utf-8")
+            (src / "file.txt").write_text("hello", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=src, check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", "init"], cwd=src, check=True, capture_output=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=src, text=True).strip()
+
+            questions_dir = tmp_path / "bench" / "questions"
+            questions_dir.mkdir(parents=True, exist_ok=True)
+            manifest_path = tmp_path / "bench" / "manifest.json"
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            results_dir = tmp_path / "bench" / "results"
+
+            q = {"id": "q1", "repo": "django", "category": "test", "query": "hello", "expected_files": ["file.txt"]}
+            (questions_dir / "q.jsonl").write_text(json.dumps(q) + "\n", encoding="utf-8")
+            manifest = {"repos": [{"name": "django", "url": str(src), "commit": commit}]}
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            orig_root = run.REPO_ROOT
+            orig_qdir = run.QUESTIONS_DIR
+            orig_rdir = run.RESULTS_DIR
+            orig_manifest = run.MANIFEST
+            orig_results_jsonl = run.RESULTS_JSONL
+            orig_adapters = dict(run.ADAPTERS)
+            orig_argv = sys.argv[:]
+            orig_env = os.environ.get("CONTEXT_BENCH_TIMING")
+            orig_results_md = run.SUMMARY_MD
+            try:
+                run.REPO_ROOT = tmp_path
+                run.QUESTIONS_DIR = questions_dir
+                run.RESULTS_DIR = results_dir
+                run.MANIFEST = manifest_path
+                run.RESULTS_JSONL = results_dir / "results.jsonl"
+                run.SUMMARY_MD = results_dir / "summary.md"
+
+                class FakeAdapter:
+                    name = "fake"
+                    def index(self, repo_path: Path):
+                        return IndexingMetrics(files_indexed=1)
+                    def search(self, query, repo_path, top_n=5):
+                        return SearchResult(query=query, hits=[], wall_ms=10, internal_ms=5, elapsed_ms=999, candidate_count=0, evidence_count=0, files_returned=0, candidate_tokens=0, packed_tokens=0)
+
+                run.ADAPTERS = {"fake": FakeAdapter}
+                if "CONTEXT_BENCH_TIMING" in os.environ:
+                    del os.environ["CONTEXT_BENCH_TIMING"]
+
+                dest = tmp_path / "bench" / "repos" / "django"
+                self.assertFalse(dest.exists())
+
+                output_path = results_dir / "results.jsonl"
+
+                sys.argv = ["run.py", "--adapters", "fake", "--repos", "django", "--profile", "smoke", "--manifest", str(manifest_path), "--output", str(output_path), "--top-n", "5"]
+                run.main()
+
+                self.assertTrue(dest.exists())
+                ignore_path = dest / ".ignore"
+                self.assertTrue(ignore_path.exists())
+                actual = ignore_path.read_text(encoding="utf-8")
+                self.assertEqual(actual, expected_django)
+
+                # rerun smoke idempotent
+                before = actual
+                sys.argv = ["run.py", "--adapters", "fake", "--repos", "django", "--profile", "smoke", "--manifest", str(manifest_path), "--output", str(output_path)]
+                run.main()
+                after = ignore_path.read_text(encoding="utf-8")
+                self.assertEqual(after, before)
+                self.assertEqual(after, expected_django)
+
+                # sentinel .context/index
+                ctx_index = dest / ".context" / "index"
+                ctx_index.mkdir(parents=True, exist_ok=True)
+                sentinel = ctx_index / "sentinel.txt"
+                sentinel.write_text("sentinel", encoding="utf-8")
+                self.assertTrue(ctx_index.exists())
+                self.assertTrue(sentinel.exists())
+
+                # official should remove bench ignore and clean sentinel
+                sys.argv = ["run.py", "--adapters", "fake", "--repos", "django", "--profile", "official", "--manifest", str(manifest_path), "--output", str(output_path)]
+                run.main()
+                self.assertFalse(ignore_path.exists())
+                self.assertFalse(ctx_index.exists())
+                self.assertTrue(dest.exists())
+            finally:
+                run.REPO_ROOT = orig_root
+                run.QUESTIONS_DIR = orig_qdir
+                run.RESULTS_DIR = orig_rdir
+                run.MANIFEST = orig_manifest
+                run.RESULTS_JSONL = orig_results_jsonl
+                run.SUMMARY_MD = orig_results_md
+                run.ADAPTERS = orig_adapters
+                sys.argv = orig_argv
+                if orig_env is not None:
+                    os.environ["CONTEXT_BENCH_TIMING"] = orig_env
+                elif "CONTEXT_BENCH_TIMING" in os.environ:
+                    del os.environ["CONTEXT_BENCH_TIMING"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/contextd/src/cli.rs
+++ b/crates/contextd/src/cli.rs
@@ -120,12 +120,23 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
                         "packed_tokens": res.stats.packed_tokens,
                         "retrievers": res.stats.retrievers_used,
                         "elapsed_ms": res.stats.elapsed_ms,
+                        "total_ms": res.stats.total_ms,
+                        "discovery_ms": res.stats.discovery_ms,
+                        "reconcile_ms": res.stats.reconcile_ms,
                         "exact_ms": res.stats.exact_ms,
                         "structural_ms": res.stats.structural_ms,
                         "bm25_ms": res.stats.bm25_ms,
                         "semantic_ms": res.stats.semantic_ms,
+                        "semantic_embed_ms": res.stats.semantic_embed_ms,
+                        "semantic_search_ms": res.stats.semantic_search_ms,
                         "rank_ms": res.stats.rank_ms,
+                        "authority_ms": res.stats.authority_ms,
+                        "fusion_ms": res.stats.fusion_ms,
                         "pack_ms": res.stats.pack_ms,
+                        "generation": res.stats.generation,
+                        "dirty_file_count": res.stats.dirty_file_count,
+                        "vector_count_scanned": res.stats.vector_count_scanned,
+                        "cache_hit": res.stats.cache_hit,
                     }
                 });
                 // Debug observability only when --debug is set, not in normal JSON output

--- a/crates/contextd/src/mcp.rs
+++ b/crates/contextd/src/mcp.rs
@@ -60,6 +60,7 @@ impl McpAdapter {
             )
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        let stats_json = serde_json::to_value(&res.stats).unwrap_or(serde_json::json!({}));
         let out = serde_json::json!({
             "query": res.query,
             "type": res.query_type.as_str(),
@@ -74,14 +75,7 @@ impl McpAdapter {
                 "authorityScore": e.authority_score,
                 "finalScore": e.final_score,
             })).collect::<Vec<_>>(),
-            "stats": {
-                "candidate_count": res.stats.candidate_count,
-                "evidence_count": res.stats.evidence_count,
-                "files_returned": res.stats.files_returned,
-                "packed_tokens": res.stats.packed_tokens,
-                "retrievers": res.stats.retrievers_used,
-                "elapsed_ms": res.stats.elapsed_ms,
-            }
+            "stats": stats_json
         });
         Ok(CallToolResult::success(vec![
             rmcp::model::ContentBlock::text(

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -56,6 +56,29 @@ pub struct PipelineStats {
     pub semantic_ms: u128,
     pub rank_ms: u128,
     pub pack_ms: u128,
+    // E1 precise stage telemetry — Option<null> when not measurable yet
+    #[serde(default)]
+    pub total_ms: Option<u128>,
+    #[serde(default)]
+    pub discovery_ms: Option<u128>,
+    #[serde(default)]
+    pub reconcile_ms: Option<u128>,
+    #[serde(default)]
+    pub semantic_embed_ms: Option<u128>,
+    #[serde(default)]
+    pub semantic_search_ms: Option<u128>,
+    #[serde(default)]
+    pub fusion_ms: Option<u128>,
+    #[serde(default)]
+    pub authority_ms: Option<u128>,
+    #[serde(default)]
+    pub generation: Option<u64>,
+    #[serde(default)]
+    pub dirty_file_count: Option<usize>,
+    #[serde(default)]
+    pub vector_count_scanned: Option<usize>,
+    #[serde(default)]
+    pub cache_hit: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -644,6 +667,9 @@ pub async fn retrieve_context(
     let mut vector_candidates: Vec<(Evidence, usize, f64)> = Vec::new();
     let mut bm25_ms: u128 = 0;
     let mut semantic_ms: u128 = 0;
+    let semantic_embed_ms: Option<u128>;
+    let semantic_search_ms: Option<u128>;
+    let mut vector_count_scanned: Option<usize> = None;
 
     // BM25 native — for SYMBOL/DEPENDENCY insufficient, fallback to raw query if no semantic_queries
     if run_bm25 {
@@ -736,8 +762,13 @@ pub async fn retrieve_context(
         if semantic_disabled {
             retrievers_used.push("rust-semantic:disabled".into());
             semantic_ms = 0;
+            semantic_embed_ms = Some(0);
+            semantic_search_ms = Some(0);
+            vector_count_scanned = None;
         } else {
             let t_sem = Instant::now();
+            let mut total_embed: u128 = 0;
+            let mut total_search: u128 = 0;
             // Use canonical configured embedder/fingerprint (CONTEXTD_EMBED_MODEL drives both indexing and query)
             let embedder: std::sync::Arc<dyn context_index::embed::Embedder> =
                 std::sync::Arc::new(context_index::embed::configured_embedder());
@@ -757,6 +788,7 @@ pub async fn retrieve_context(
             for sq in &semantic_queries {
                 let q = sq.clone();
                 // Embed query without holding DB connection (Connection is !Send)
+                let t_embed = Instant::now();
                 let qvec = {
                     let cached = context_index::embed::QUERY_CACHE.get(&fp, &q).await;
                     if let Some(v) = cached {
@@ -777,14 +809,23 @@ pub async fn retrieve_context(
                         }
                     }
                 };
+                total_embed = total_embed.saturating_add(t_embed.elapsed().as_millis());
                 // Now open DB for brute search (moved off async executor thread)
                 let conn = structural_store::open_db_async(project.root.clone()).await?;
                 let cnt = context_index::vector::count_vectors(&conn, &fp).unwrap_or(0);
                 if cnt == 0 {
                     tracing::debug!("no vectors for model {}, skipping semantic", fp.model_id);
                     retrievers_used.push(format!("rust-semantic:0:{}", fp.model_id));
+                    vector_count_scanned = Some(0);
                     continue;
                 }
+                if vector_count_scanned.is_none() {
+                    vector_count_scanned = Some(cnt as usize);
+                } else {
+                    // keep max
+                    vector_count_scanned = Some(vector_count_scanned.unwrap().max(cnt as usize));
+                }
+                let t_search = Instant::now();
                 match context_index::vector::search_brute(
                     &conn,
                     &qvec,
@@ -827,11 +868,17 @@ pub async fn retrieve_context(
                         retrievers_used.push("rust-semantic:0".into());
                     }
                 }
+                total_search = total_search.saturating_add(t_search.elapsed().as_millis());
             }
             semantic_ms = t_sem.elapsed().as_millis();
+            semantic_embed_ms = Some(total_embed);
+            semantic_search_ms = Some(total_search);
         }
     } else {
         retrievers_used.push("rust-semantic:skipped".into());
+        semantic_embed_ms = None;
+        semantic_search_ms = None;
+        vector_count_scanned = None;
     }
 
     // Fuse BM25 + vector via RRF (rank-normalized)
@@ -970,6 +1017,17 @@ pub async fn retrieve_context(
         semantic_ms,
         rank_ms,
         pack_ms,
+        total_ms: Some(elapsed_ms),
+        discovery_ms: None,
+        reconcile_ms: None,
+        semantic_embed_ms,
+        semantic_search_ms,
+        fusion_ms: Some(fuse_ms),
+        authority_ms: Some(rank_ms),
+        generation: None,
+        dirty_file_count: None,
+        vector_count_scanned,
+        cache_hit: None,
     };
 
     Ok(ContextResult {

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -861,14 +861,15 @@ pub async fn retrieve_context(
                             q.chars().take(15).collect::<String>(),
                             vector_candidates.len()
                         ));
+                        total_search = total_search.saturating_add(t_search.elapsed().as_millis());
                         break;
                     }
                     Err(e) => {
                         tracing::debug!(error=%e, "vector search failed");
                         retrievers_used.push("rust-semantic:0".into());
+                        total_search = total_search.saturating_add(t_search.elapsed().as_millis());
                     }
                 }
-                total_search = total_search.saturating_add(t_search.elapsed().as_millis());
             }
             semantic_ms = t_sem.elapsed().as_millis();
             semantic_embed_ms = Some(total_embed);

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -371,17 +371,10 @@ impl ContextService {
         opts: SearchOptions,
     ) -> Result<ContextResult, ContextError> {
         let t_search = std::time::Instant::now();
-        let (reconcile_stats, _first_project, first_discovery_ms) = self
+        let (reconcile_stats, project, discovery_ms) = self
             .reconcile_fast_with_index_inner(None)
             .await
             .map_err(|e| ContextError::Internal(format!("reconcile failed: {e}")))?;
-        let root = ProjectRoot::resolve(Some(&self.root))
-            .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
-        let t_second_discover = std::time::Instant::now();
-        let project =
-            ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
-        let second_discovery_ms = t_second_discover.elapsed().as_millis();
-        let total_discovery_ms = first_discovery_ms.saturating_add(second_discovery_ms);
         let providers = Providers {};
         let mut res = retrieve_context(
             query,
@@ -394,11 +387,11 @@ impl ContextService {
         .map_err(|e| ContextError::Internal(e.to_string()))?;
         // Fill stage telemetry at service layer
         let total_ms = t_search.elapsed().as_millis();
-        let generation = structural_store::open_db(root.path())
+        let generation = structural_store::open_db(&project.root)
             .ok()
             .and_then(|c| structural_store::get_generation(&c).ok());
         res.stats.total_ms = Some(total_ms);
-        res.stats.discovery_ms = Some(total_discovery_ms);
+        res.stats.discovery_ms = Some(discovery_ms);
         res.stats.reconcile_ms = Some(reconcile_stats.elapsed_ms);
         res.stats.generation = generation;
         // dirty_file_count stays None until E2 (no dirty tracking yet)
@@ -429,13 +422,12 @@ impl ContextService {
         opts: SearchOptions,
     ) -> Result<ContextResult, ContextError> {
         // Graph-native dependency retrieval: directly query call graph, not via generic search
+        // E1: reconcile already does one discovery; remove duplicate unused ProjectIndex::discover
         self.reconcile_fast_inner(None)
             .await
             .map_err(|e| ContextError::Internal(format!("reconcile failed: {e}")))?;
         let root = ProjectRoot::resolve(Some(&self.root))
             .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
-        let _project =
-            ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
         let t0 = std::time::Instant::now();
         let mut candidates: Vec<context_rank::types::Evidence> = Vec::new();
         let mut retrievers_used = Vec::new();

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -231,6 +231,16 @@ impl ContextService {
         &self,
         override_embedder: Option<Arc<dyn Embedder>>,
     ) -> Result<ReconcileStats, ContextError> {
+        let (stats, _idx, _discovery_ms) = self
+            .reconcile_fast_with_index_inner(override_embedder)
+            .await?;
+        Ok(stats)
+    }
+
+    async fn reconcile_fast_with_index_inner(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<(ReconcileStats, ProjectIndex, u128), ContextError> {
         let _guard = self.build_lock.lock().await;
         let t0 = std::time::Instant::now();
         let root = ProjectRoot::resolve(Some(&self.root))
@@ -246,8 +256,10 @@ impl ContextService {
         } else {
             false
         };
+        let t_discover = std::time::Instant::now();
         let idx =
             ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
+        let discovery_ms = t_discover.elapsed().as_millis();
         let root_path = root.path().to_path_buf();
         let idx_clone = idx.clone();
         let outcome = tokio::task::spawn_blocking(move || {
@@ -315,7 +327,7 @@ impl ContextService {
         }
 
         let elapsed = t0.elapsed().as_millis();
-        Ok(ReconcileStats {
+        let stats = ReconcileStats {
             discovered: idx.stats.discovered,
             changed_files: outcome.changed_files.len(),
             deleted_files: outcome.deleted_files.len(),
@@ -323,7 +335,8 @@ impl ContextService {
             vectors_created,
             vectors_reused,
             embedding_calls,
-        })
+        };
+        Ok((stats, idx, discovery_ms))
     }
 
     /// Cheap reconcile — discovery + incremental structural/BM25 + semantic if available (fast, incremental only).
@@ -357,15 +370,20 @@ impl ContextService {
         query: &str,
         opts: SearchOptions,
     ) -> Result<ContextResult, ContextError> {
-        self.reconcile_fast_inner(None)
+        let t_search = std::time::Instant::now();
+        let (reconcile_stats, _first_project, first_discovery_ms) = self
+            .reconcile_fast_with_index_inner(None)
             .await
             .map_err(|e| ContextError::Internal(format!("reconcile failed: {e}")))?;
         let root = ProjectRoot::resolve(Some(&self.root))
             .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
+        let t_second_discover = std::time::Instant::now();
         let project =
             ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
+        let second_discovery_ms = t_second_discover.elapsed().as_millis();
+        let total_discovery_ms = first_discovery_ms.saturating_add(second_discovery_ms);
         let providers = Providers {};
-        retrieve_context(
+        let mut res = retrieve_context(
             query,
             &project,
             &providers,
@@ -373,7 +391,27 @@ impl ContextService {
             opts.max_results,
         )
         .await
-        .map_err(|e| ContextError::Internal(e.to_string()))
+        .map_err(|e| ContextError::Internal(e.to_string()))?;
+        // Fill stage telemetry at service layer
+        let total_ms = t_search.elapsed().as_millis();
+        let generation = structural_store::open_db(root.path())
+            .ok()
+            .and_then(|c| structural_store::get_generation(&c).ok());
+        res.stats.total_ms = Some(total_ms);
+        res.stats.discovery_ms = Some(total_discovery_ms);
+        res.stats.reconcile_ms = Some(reconcile_stats.elapsed_ms);
+        res.stats.generation = generation;
+        // dirty_file_count stays None until E2 (no dirty tracking yet)
+        res.stats.dirty_file_count = None;
+        res.stats.cache_hit = None;
+        // ensure authority/fusion mirrored if not set
+        if res.stats.authority_ms.is_none() {
+            res.stats.authority_ms = Some(res.stats.rank_ms);
+        }
+        if res.stats.fusion_ms.is_none() {
+            res.stats.fusion_ms = Some(res.stats.pack_ms);
+        }
+        Ok(res)
     }
 
     pub async fn symbol(
@@ -650,6 +688,17 @@ impl ContextService {
             semantic_ms: 0,
             rank_ms,
             pack_ms,
+            total_ms: Some(elapsed_ms),
+            discovery_ms: None,
+            reconcile_ms: None,
+            semantic_embed_ms: None,
+            semantic_search_ms: None,
+            fusion_ms: Some(fuse_ms),
+            authority_ms: Some(rank_ms),
+            generation: None,
+            dirty_file_count: None,
+            vector_count_scanned: None,
+            cache_hit: None,
         };
         Ok(crate::pipeline::ContextResult {
             query: symbol.to_string(),

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -397,12 +397,8 @@ impl ContextService {
         // dirty_file_count stays None until E2 (no dirty tracking yet)
         res.stats.dirty_file_count = None;
         res.stats.cache_hit = None;
-        // ensure authority/fusion mirrored if not set
         if res.stats.authority_ms.is_none() {
             res.stats.authority_ms = Some(res.stats.rank_ms);
-        }
-        if res.stats.fusion_ms.is_none() {
-            res.stats.fusion_ms = Some(res.stats.pack_ms);
         }
         Ok(res)
     }


### PR DESCRIPTION
## **User description**
## 1 Performance

- ProjectIndex::discover/search 2 -> 1
- dependency discovery 2 -> 1
- reconcile calls remain 1
- Django Cold wall 15330 -> 8019 ms, Hot wall 14955 -> 7605 ms, Discovery 5551 -> 2714 ms
- NestJS Cold wall 4054 -> 3116 ms, Hot wall 3866 -> 2989 ms, Discovery 1917 -> 941 ms
- ripgrep Cold wall 1209 -> 1083 ms, Hot wall 1118 -> 1016 ms, Discovery 193 -> 93 ms
- discovery improved roughly 49-52%; internal retrieval stayed essentially flat; retrieval rankings were unchanged

Removes duplicate repository discovery passes without changing query semantics.

## 2 Benchmark foundation

- cold CLI benchmark
- persistent MCP hot benchmark
- wall/internal/total timing separation
- stage telemetry
- persistent PID verified

Foundation enables isolated measurement of discovery vs search vs ranking.

## 3 Correctness

Controlled same-environment revisions: BASE 2e64542, TELEMETRY 58a75cc, E1 dbc2a54.

- 18Q identical Hit@1 .500 Hit@3 .611 Hit@5 .611 MRR .556
- 26Q identical Hit@1 .500 Hit@3 .654 Hit@5 .654 MRR .571
- Expected-file ranks identical across all three revisions.

No retrieval regression attributable to telemetry or deduplication.

## 4 Historical discrepancy

Historical smoke and current official/full-corpus results are not directly comparable.

- Historical measured smoke 18Q .556/.722/.778 MRR .644 and 26Q .538/.731/.769 MRR .631.
- Current official semantic-ready 18Q .500/.611/.611 MRR .556 and 26Q .500/.654/.654 MRR .571.
- Apparent regression was environment/profile drift, NOT E1.

Comparison must use same environment/profile/corpus; controlled re-run above confirms E1 is neutral.

## 5 Semantic state

- all five pinned repos semantic-ready
- missing vectors=0
- all-minilm 384d
- representation v2

## 6 Gates

- fmt PASS
- clippy PASS
- tests PASS
- release PASS

## 7 Scope

No watcher redesign, dirty gating, result cache, ANN/HNSW, hot vector store, ranking changes, LSP/SCIP.

This PR is limited to performance telemetry and duplicate discovery removal only.


___

## **CodeAnt-AI Description**
Add search performance telemetry and benchmark tooling while removing duplicate repository scans

### What Changed
- Search and dependency lookups avoid repeating repository discovery, reducing the work required for each request without changing result ranking.
- CLI and MCP search responses now expose timing for discovery, reconciliation, semantic embedding and search, fusion, authority ranking, packing, and total request duration.
- Search statistics now include index generation, scanned vector count, and explicitly unavailable values for metrics that cannot yet be measured.
- Added cold, warm, and persistent-process benchmark support with separate wall-clock and internal engine timings.
- Benchmark reports evaluate unique files and provide retrieval metrics such as Hit@K, Recall@K, and MRR across pinned repositories.

### Impact
`✅ Faster repository search`
`✅ Faster dependency lookups`
`✅ Clearer search performance diagnostics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

