### PR TITLE
R5.1-E2: Add persistent repository runtime and dirty-gated reconcile

### DIFF
--- a/bench/adapters/context_engine.py
+++ b/bench/adapters/context_engine.py
@@ -303,6 +303,10 @@ class ContextEngineAdapter(BenchmarkAdapter):
         dirty = g("dirty_file_count", "dirtyFileCount", None)
         vector_scanned = g("vector_count_scanned", "vectorCountScanned", None)
         cache_hit = g("cache_hit", "cacheHit", None)
+        reconcile_skipped = g("reconcile_skipped", "reconcileSkipped", None)
+        discovery_calls = g("discovery_calls", "discoveryCalls", None)
+        reconcile_calls = g("reconcile_calls", "reconcileCalls", None)
+        runtime_state = g("runtime_state", "runtimeState", None)
 
         # candidate_tokens: not exposed by production; leave None honestly
         candidate_tokens = None
@@ -355,6 +359,10 @@ class ContextEngineAdapter(BenchmarkAdapter):
             dirty_file_count=int(dirty) if dirty is not None else None,
             vector_count_scanned=int(vector_scanned) if vector_scanned is not None else None,
             cache_hit=bool(cache_hit_inferred) if cache_hit_inferred is not None else None,
+            reconcile_skipped=bool(reconcile_skipped) if reconcile_skipped is not None else None,
+            discovery_calls=int(discovery_calls) if discovery_calls is not None else None,
+            reconcile_calls=int(reconcile_calls) if reconcile_calls is not None else None,
+            runtime_state=str(runtime_state) if runtime_state is not None else None,
             process_pid=None,
             startup_ms=None,
             raw={**data, "wall_ms": wall_ms, "internal_ms": internal_ms, "cache_hit_inferred": cache_hit_inferred},

--- a/bench/adapters/context_engine_hot.py
+++ b/bench/adapters/context_engine_hot.py
@@ -398,6 +398,10 @@ class ContextEngineHotAdapter(BenchmarkAdapter):
         generation = g("generation", "generation", None)
         dirty = g("dirty_file_count", "dirtyFileCount", None)
         vector_scanned = g("vector_count_scanned", "vectorCountScanned", None)
+        reconcile_skipped = g("reconcile_skipped", "reconcileSkipped", None)
+        discovery_calls = g("discovery_calls", "discoveryCalls", None)
+        reconcile_calls = g("reconcile_calls", "reconcileCalls", None)
+        runtime_state = g("runtime_state", "runtimeState", None)
 
         # hot must report both wall and internal
         # wall is adapter-measured per query (excludes startup), internal is engine pipeline
@@ -461,6 +465,10 @@ class ContextEngineHotAdapter(BenchmarkAdapter):
             dirty_file_count=int(dirty) if dirty is not None else None,
             vector_count_scanned=int(vector_scanned) if vector_scanned is not None else None,
             cache_hit=cache_hit_val,
+            reconcile_skipped=bool(reconcile_skipped) if reconcile_skipped is not None else None,
+            discovery_calls=int(discovery_calls) if discovery_calls is not None else None,
+            reconcile_calls=int(reconcile_calls) if reconcile_calls is not None else None,
+            runtime_state=str(runtime_state) if runtime_state is not None else None,
             process_pid=pid_for_query,
             startup_ms=startup_for_query,
             raw={

--- a/bench/adapters/interface.py
+++ b/bench/adapters/interface.py
@@ -63,6 +63,11 @@ class SearchResult:
     cache_hit: Optional[bool] = None
     process_pid: Optional[int] = None
     startup_ms: Optional[int] = None
+    # E2 runtime telemetry (Option/null when not exposed)
+    reconcile_skipped: Optional[bool] = None
+    discovery_calls: Optional[int] = None
+    reconcile_calls: Optional[int] = None
+    runtime_state: Optional[str] = None
     # Raw for debugging
     raw: Optional[Dict] = None
 

--- a/bench/tests/test_run.py
+++ b/bench/tests/test_run.py
@@ -162,5 +162,148 @@ class TestSmokeIntegration(unittest.TestCase):
                     del os.environ["CONTEXT_BENCH_TIMING"]
 
 
+class TestRuntimeTelemetry(unittest.TestCase):
+    def test_search_result_exposes_runtime_fields(self):
+        sr = SearchResult(
+            query="q",
+            reconcile_skipped=True,
+            discovery_calls=0,
+            reconcile_calls=0,
+            runtime_state="clean",
+        )
+        self.assertTrue(sr.reconcile_skipped is True)
+        self.assertEqual(sr.discovery_calls, 0)
+        self.assertEqual(sr.reconcile_calls, 0)
+        self.assertEqual(sr.runtime_state, "clean")
+
+    def test_missing_runtime_fields_remain_none_when_durations_present(self):
+        sr = SearchResult(query="q", discovery_ms=12, reconcile_ms=7)
+        self.assertIsNone(sr.reconcile_skipped)
+        self.assertIsNone(sr.discovery_calls)
+        self.assertIsNone(sr.reconcile_calls)
+        self.assertIsNone(sr.runtime_state)
+
+    def test_cold_adapter_maps_camel_and_snake_without_inferring_zeros(self):
+        from unittest.mock import patch
+        import bench.adapters.context_engine as ce_mod
+        from bench.adapters.context_engine import ContextEngineAdapter
+
+        # helper to make adapter without building
+        adapter = ContextEngineAdapter.__new__(ContextEngineAdapter)
+        adapter._bin = Path("/tmp/fake_contextd")
+
+        camel_data = {
+            "evidence": [],
+            "stats": {
+                "reconcileSkipped": True,
+                "discoveryCalls": 0,
+                "reconcileCalls": 0,
+                "runtimeState": "clean",
+                "discoveryMs": 1,
+                "reconcileMs": 2,
+            },
+            "context": "",
+        }
+        snake_data = {
+            "evidence": [],
+            "stats": {
+                "reconcile_skipped": False,
+                "discovery_calls": 3,
+                "reconcile_calls": 1,
+                "runtime_state": "dirty",
+            },
+            "context": "",
+        }
+        only_durations = {
+            "evidence": [],
+            "stats": {"discoveryMs": 9, "reconcileMs": 4},
+            "context": "",
+        }
+
+        with patch.object(ce_mod, "_run_json", return_value=camel_data):
+            res = adapter.search("q", Path("/tmp"), top_n=5)
+            self.assertTrue(res.reconcile_skipped is True)
+            self.assertEqual(res.discovery_calls, 0)
+            self.assertEqual(res.reconcile_calls, 0)
+            self.assertEqual(res.runtime_state, "clean")
+
+        with patch.object(ce_mod, "_run_json", return_value=snake_data):
+            res = adapter.search("q", Path("/tmp"), top_n=5)
+            self.assertTrue(res.reconcile_skipped is False)
+            self.assertEqual(res.discovery_calls, 3)
+            self.assertEqual(res.reconcile_calls, 1)
+            self.assertEqual(res.runtime_state, "dirty")
+
+        with patch.object(ce_mod, "_run_json", return_value=only_durations):
+            res = adapter.search("q", Path("/tmp"), top_n=5)
+            self.assertIsNone(res.reconcile_skipped)
+            self.assertIsNone(res.discovery_calls)
+            self.assertIsNone(res.reconcile_calls)
+            self.assertIsNone(res.runtime_state)
+
+    def test_hot_adapter_maps_camel_and_snake_without_inferring_zeros(self):
+        from bench.adapters.context_engine_hot import ContextEngineHotAdapter
+
+        adapter = ContextEngineHotAdapter.__new__(ContextEngineHotAdapter)
+        adapter._bin = Path("/tmp/fake_contextd")
+        adapter._clients = {}
+
+        class FakeClient:
+            def __init__(self, payload):
+                self.payload = payload
+                self.contextd_pid = 1234
+                self.startup_ms = 10
+
+            def search(self, query, max_results=5, budget_tokens=10000, timeout=180):
+                return self.payload
+
+        camel = {
+            "evidence": [],
+            "stats": {
+                "reconcileSkipped": True,
+                "discoveryCalls": 0,
+                "reconcileCalls": 0,
+                "runtimeState": "clean",
+            },
+        }
+        snake = {
+            "evidence": [],
+            "stats": {
+                "reconcile_skipped": True,
+                "discovery_calls": 0,
+                "reconcile_calls": 0,
+                "runtime_state": "clean",
+            },
+        }
+        only_durations = {
+            "evidence": [],
+            "stats": {"discovery_ms": 15, "reconcile_ms": 6},
+        }
+
+        fake_camel = FakeClient(camel)
+        adapter._client_for = lambda _p: fake_camel  # type: ignore
+        res = adapter.search("q", Path("/tmp"), top_n=5)
+        self.assertTrue(res.reconcile_skipped is True)
+        self.assertEqual(res.discovery_calls, 0)
+        self.assertEqual(res.reconcile_calls, 0)
+        self.assertEqual(res.runtime_state, "clean")
+
+        fake_snake = FakeClient(snake)
+        adapter._client_for = lambda _p: fake_snake  # type: ignore
+        res = adapter.search("q", Path("/tmp"), top_n=5)
+        self.assertTrue(res.reconcile_skipped is True)
+        self.assertEqual(res.discovery_calls, 0)
+        self.assertEqual(res.reconcile_calls, 0)
+        self.assertEqual(res.runtime_state, "clean")
+
+        fake_durations = FakeClient(only_durations)
+        adapter._client_for = lambda _p: fake_durations  # type: ignore
+        res = adapter.search("q", Path("/tmp"), top_n=5)
+        self.assertIsNone(res.reconcile_skipped)
+        self.assertIsNone(res.discovery_calls)
+        self.assertIsNone(res.reconcile_calls)
+        self.assertIsNone(res.runtime_state)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/crates/context-index/src/discovery.rs
+++ b/crates/context-index/src/discovery.rs
@@ -287,17 +287,13 @@ fn is_symlink_tainted(root: &Path, rel: &str) -> bool {
     // Prevents incremental reads outside root and aligns full/incremental.
     let mut prefix = PathBuf::new();
     for comp in Path::new(rel).components() {
-        match comp {
-            Component::Normal(os) => {
-                prefix.push(os);
-                let abs = root.join(&prefix);
-                if let Ok(md) = std::fs::symlink_metadata(&abs) {
-                    if md.file_type().is_symlink() {
-                        return true;
-                    }
-                }
+        if let Component::Normal(os) = comp {
+            prefix.push(os);
+            if std::fs::symlink_metadata(root.join(&prefix))
+                .is_ok_and(|md| md.file_type().is_symlink())
+            {
+                return true;
             }
-            _ => {}
         }
     }
     false

--- a/crates/context-index/src/discovery.rs
+++ b/crates/context-index/src/discovery.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::SystemTime;
 
 use context_core::ContextError;
@@ -191,11 +191,11 @@ impl ProjectIndex {
         let mut deleted = Vec::new();
 
         for rel in paths {
-            let norm = rel.replace('\\', "/").trim_start_matches("./").to_string();
-            let old = files.iter().find(|f| f.relative_path == norm).cloned();
-            if let Some(pos) = files.iter().position(|f| f.relative_path == norm) {
-                files.remove(pos);
-            }
+            let norm = normalize_rel_path(rel)?;
+            let old = match files.iter().position(|f| f.relative_path == norm) {
+                Some(pos) => Some(files.remove(pos)),
+                None => None,
+            };
             let mut scratch = ScanStats::default();
             if let Some(new) = make_record(&self.root, &norm, true, &mut scratch) {
                 let is_changed = match &old {
@@ -220,7 +220,9 @@ impl ProjectIndex {
         changed.sort();
         deleted.sort();
 
-        let stats = recompute_stats(&files);
+        let mut stats = recompute_stats(&files);
+        stats.skipped_generated = self.stats.skipped_generated;
+        stats.hash_errors = self.stats.hash_errors;
 
         Ok(ProjectIndexDelta {
             project: ProjectIndex {
@@ -232,6 +234,33 @@ impl ProjectIndex {
             deleted_files: deleted,
         })
     }
+}
+
+/// Normalize a caller-supplied path to posix style and reject any path that
+/// would escape the project root: empty, absolute, root/prefix, or `..`.
+fn normalize_rel_path(rel: &str) -> Result<String, ContextError> {
+    let norm = rel.replace('\\', "/").trim_start_matches("./").to_string();
+    if norm.is_empty() {
+        return Err(ContextError::InvalidParams("empty path".into()));
+    }
+    for comp in Path::new(&norm).components() {
+        match comp {
+            Component::ParentDir => {
+                return Err(ContextError::InvalidParams(format!(
+                    "path escapes project root: {}",
+                    rel
+                )));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(ContextError::InvalidParams(format!(
+                    "absolute path not allowed: {}",
+                    rel
+                )));
+            }
+            _ => {}
+        }
+    }
+    Ok(norm)
 }
 
 /// Build a single `FileRecord` from a relative posix path.
@@ -262,6 +291,9 @@ fn make_record(
         Ok(m) => m,
         Err(_) => return None,
     };
+    if meta.is_dir() {
+        return None;
+    }
     let size = meta.len();
     stats.total_bytes += size;
     match kind {
@@ -314,12 +346,6 @@ fn recompute_stats(files: &[FileRecord]) -> ScanStats {
             FileKind::Build => stats.build += 1,
             FileKind::Generated => stats.generated += 1,
             FileKind::Unknown => stats.unknown += 1,
-        }
-        if f.content_hash.is_none()
-            && is_text_searchable(&f.relative_path, f.kind)
-            && f.size_bytes <= 10 * 1024 * 1024
-        {
-            stats.hash_errors += 1;
         }
     }
     stats
@@ -379,6 +405,7 @@ fn is_text_searchable(rel: &str, kind: FileKind) -> bool {
 mod tests {
     use super::*;
     use crate::project_root::ProjectRoot;
+    use context_core::ContextError;
     use std::collections::BTreeSet;
     use std::fs;
     use tempfile::TempDir;
@@ -600,5 +627,90 @@ mod tests {
         assert_eq!(delta.project.stats.source, 2);
         assert_eq!(delta.project.stats.doc, 0);
         assert_eq!(delta.project.stats.total_bytes, 5 + 12);
+    }
+
+    #[test]
+    fn refresh_paths_rejects_parent_dir() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let paths: BTreeSet<String> = ["../secret.txt".to_string()].into_iter().collect();
+        let err = idx.refresh_paths(&paths).unwrap_err();
+        assert!(matches!(err, ContextError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn refresh_paths_rejects_absolute() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let abs = tmp.path().join("a.py").to_string_lossy().replace('\\', "/");
+        let paths: BTreeSet<String> = [abs].into_iter().collect();
+        let err = idx.refresh_paths(&paths).unwrap_err();
+        assert!(matches!(err, ContextError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn refresh_paths_rejects_empty() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let paths: BTreeSet<String> = ["".to_string()].into_iter().collect();
+        let err = idx.refresh_paths(&paths).unwrap_err();
+        assert!(matches!(err, ContextError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn refresh_paths_directory_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        fs::create_dir_all(tmp.path().join("subdir")).unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let paths: BTreeSet<String> = ["subdir".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(!delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "subdir"));
+        assert!(delta.changed_files.is_empty());
+        assert!(delta.deleted_files.is_empty());
+    }
+
+    #[test]
+    fn refresh_paths_preserves_skipped_generated() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        fs::create_dir_all(tmp.path().join("target/debug")).unwrap();
+        fs::write(tmp.path().join("target/debug/foo"), b"bin").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        assert!(idx.stats.skipped_generated > 0);
+        fs::write(tmp.path().join("b.py"), b"world").unwrap();
+        let paths: BTreeSet<String> = ["b.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert_eq!(
+            delta.project.stats.skipped_generated,
+            idx.stats.skipped_generated
+        );
+    }
+
+    #[test]
+    fn refresh_paths_preserves_hash_errors() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        fs::write(tmp.path().join("b.md"), b"# doc").unwrap();
+        let idx = ProjectIndex::discover_with_options(&root, false).unwrap();
+        assert_eq!(idx.stats.hash_errors, 0);
+        fs::write(tmp.path().join("a.py"), b"hello world").unwrap();
+        let paths: BTreeSet<String> = ["a.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert_eq!(delta.project.stats.hash_errors, idx.stats.hash_errors);
+        assert_eq!(delta.project.stats.hash_errors, 0);
     }
 }

--- a/crates/context-index/src/discovery.rs
+++ b/crates/context-index/src/discovery.rs
@@ -100,24 +100,7 @@ impl ProjectIndex {
         let mut files = Vec::new();
         let mut stats = ScanStats::default();
 
-        // Use `ignore` WalkBuilder which respects .gitignore, .ignore, and hidden.
-        // Add overrides for ENGINE_INTERNAL_EXCLUDES and .opencodeignore.
-        let mut builder = WalkBuilder::new(root_path);
-        builder
-            .hidden(false) // don't hide . files by default; let gitignore handle
-            .git_ignore(true)
-            .git_global(false)
-            .git_exclude(false)
-            .parents(true)
-            .ignore(true) // .ignore
-            .require_git(true) // only if git repo
-            .follow_links(false);
-
-        // Add custom ignore for .opencodeignore if present
-        let opencode_ignore = root_path.join(".opencodeignore");
-        if opencode_ignore.exists() {
-            builder.add_ignore(opencode_ignore);
-        }
+        let builder = build_walk(root_path);
 
         // Walk
         for entry in builder.build() {
@@ -189,6 +172,9 @@ impl ProjectIndex {
         let mut files = self.files.clone();
         let mut changed = Vec::new();
         let mut deleted = Vec::new();
+        // Reuse WalkBuilder config via IncrementalIgnore without a recursive walk.
+        let builder = build_walk(&self.root);
+        let mut matcher = builder.build_matchers().into_iter().next().unwrap();
 
         for rel in paths {
             let norm = normalize_rel_path(rel)?;
@@ -196,6 +182,21 @@ impl ProjectIndex {
                 .iter()
                 .position(|f| f.relative_path == norm)
                 .map(|pos| files.remove(pos));
+            // Symlink check before any metadata/ignore stat to prevent reads outside root.
+            if is_symlink_tainted(&self.root, &norm) {
+                if old.is_some() {
+                    deleted.push(norm.clone());
+                }
+                continue;
+            }
+            // Mirror WalkBuilder filtering: hidden, gitignore, ignore, opencodeignore etc.
+            // `matched` checks hierarchical ignore files; treat Ignore as absent.
+            if matcher.matched(&norm, false).is_ignore() {
+                if old.is_some() {
+                    deleted.push(norm.clone());
+                }
+                continue;
+            }
             let mut scratch = ScanStats::default();
             if let Some(new) = make_record(&self.root, &norm, true, &mut scratch) {
                 let is_changed = match &old {
@@ -263,6 +264,45 @@ fn normalize_rel_path(rel: &str) -> Result<String, ContextError> {
     Ok(norm)
 }
 
+fn build_walk(root_path: &Path) -> WalkBuilder {
+    let mut builder = WalkBuilder::new(root_path);
+    builder
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(false)
+        .git_exclude(false)
+        .parents(true)
+        .ignore(true)
+        .require_git(true)
+        .follow_links(false);
+    let opencode_ignore = root_path.join(".opencodeignore");
+    if opencode_ignore.exists() {
+        builder.add_ignore(opencode_ignore);
+    }
+    builder
+}
+
+fn is_symlink_tainted(root: &Path, rel: &str) -> bool {
+    // Reject if the candidate itself or any component below root is a symlink.
+    // Prevents incremental reads outside root and aligns full/incremental.
+    let mut prefix = PathBuf::new();
+    for comp in Path::new(rel).components() {
+        match comp {
+            Component::Normal(os) => {
+                prefix.push(os);
+                let abs = root.join(&prefix);
+                if let Ok(md) = std::fs::symlink_metadata(&abs) {
+                    if md.file_type().is_symlink() {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 /// Build a single `FileRecord` from a relative posix path.
 /// Updates `stats` to reflect the record, mirroring the logic in full discovery.
 fn make_record(
@@ -271,6 +311,10 @@ fn make_record(
     do_hash: bool,
     stats: &mut ScanStats,
 ) -> Option<FileRecord> {
+    // Before metadata/hashing, reject symlink or symlink component
+    if is_symlink_tainted(root_path, rel) {
+        return None;
+    }
     let path = root_path.join(rel);
 
     // Engine-internal check
@@ -714,5 +758,211 @@ mod tests {
         let delta = idx.refresh_paths(&paths).unwrap();
         assert_eq!(delta.project.stats.hash_errors, idx.stats.hash_errors);
         assert_eq!(delta.project.stats.hash_errors, 0);
+    }
+
+    #[test]
+    fn refresh_paths_ignores_gitignore_new_file() {
+        let tmp = TempDir::new().unwrap();
+        // require_git(true) needs a .git dir for .gitignore to be respected
+        fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join(".gitignore"), b"ignored_git.py\n").unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        assert!(idx.files.iter().any(|f| f.relative_path == "a.py"));
+        assert!(!idx
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_git.py"));
+        // Create a file that matches .gitignore and try incremental refresh
+        fs::write(tmp.path().join("ignored_git.py"), b"should be ignored").unwrap();
+        let paths: BTreeSet<String> = ["ignored_git.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(
+            !delta
+                .project
+                .files
+                .iter()
+                .any(|f| f.relative_path == "ignored_git.py"),
+            "refresh must not index .gitignore'd file"
+        );
+        assert!(delta.changed_files.is_empty());
+        assert!(delta.deleted_files.is_empty());
+        // Parity with full discover
+        let full = ProjectIndex::discover(&root).unwrap();
+        assert!(!full
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_git.py"));
+    }
+
+    #[test]
+    fn refresh_paths_ignores_ignore_new_file() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".ignore"), b"ignored_tool.py\n").unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        assert!(!idx
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_tool.py"));
+        fs::write(tmp.path().join("ignored_tool.py"), b"should be ignored").unwrap();
+        let paths: BTreeSet<String> = ["ignored_tool.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(!delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_tool.py"));
+        assert!(delta.changed_files.is_empty());
+        let full = ProjectIndex::discover(&root).unwrap();
+        assert!(!full
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_tool.py"));
+    }
+
+    #[test]
+    fn refresh_paths_ignores_opencodeignore_new_file() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".opencodeignore"), b"ignored_open.py\n").unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        assert!(!idx
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_open.py"));
+        fs::write(tmp.path().join("ignored_open.py"), b"should be ignored").unwrap();
+        let paths: BTreeSet<String> = ["ignored_open.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(!delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_open.py"));
+        assert!(delta.changed_files.is_empty());
+        let full = ProjectIndex::discover(&root).unwrap();
+        assert!(!full
+            .files
+            .iter()
+            .any(|f| f.relative_path == "ignored_open.py"));
+    }
+
+    #[test]
+    fn refresh_paths_removes_now_ignored_file() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        fs::write(tmp.path().join("keep.py"), b"hello").unwrap();
+        fs::write(tmp.path().join("to_ignore.py"), b"hello").unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        assert!(idx.files.iter().any(|f| f.relative_path == "to_ignore.py"));
+        // Now add ignore rule that matches the previously-indexed file
+        fs::write(tmp.path().join(".gitignore"), b"to_ignore.py\n").unwrap();
+        // File still exists on disk; refresh should evict it
+        let paths: BTreeSet<String> = ["to_ignore.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(!delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "to_ignore.py"));
+        assert_eq!(delta.deleted_files, vec!["to_ignore.py"]);
+        assert!(delta.changed_files.is_empty());
+        let full = ProjectIndex::discover(&root).unwrap();
+        assert!(!full.files.iter().any(|f| f.relative_path == "to_ignore.py"));
+    }
+
+    #[test]
+    fn refresh_paths_rejects_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+
+        // Create a target outside the project root
+        let outside_dir = TempDir::new().unwrap();
+        let outside_file = outside_dir.path().join("secret.txt");
+        fs::write(&outside_file, b"secret").unwrap();
+
+        let link_path = tmp.path().join("link.py");
+        let res = {
+            #[cfg(unix)]
+            {
+                std::os::unix::fs::symlink(&outside_file, &link_path)
+            }
+            #[cfg(windows)]
+            {
+                std::os::windows::fs::symlink_file(&outside_file, &link_path)
+            }
+            #[cfg(not(any(unix, windows)))]
+            {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "unsupported",
+                ))
+            }
+        };
+        if res.is_err() {
+            // Windows without privilege: early return per spec
+            return;
+        }
+
+        let paths: BTreeSet<String> = ["link.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(
+            !delta
+                .project
+                .files
+                .iter()
+                .any(|f| f.relative_path == "link.py"),
+            "symlink must not be indexed via refresh"
+        );
+        assert!(delta.changed_files.is_empty());
+        // Full discovery must also not index the symlink
+        let full = ProjectIndex::discover(&root).unwrap();
+        assert!(!full.files.iter().any(|f| f.relative_path == "link.py"));
+        // Also test symlink component: dir symlink
+        #[cfg(unix)]
+        {
+            let outside_sub = outside_dir.path().join("sub");
+            fs::create_dir_all(&outside_sub).unwrap();
+            fs::write(outside_sub.join("evil.py"), b"evil").unwrap();
+            let link_dir = tmp.path().join("linkdir");
+            let res2 = std::os::unix::fs::symlink(&outside_sub, &link_dir);
+            if res2.is_ok() {
+                let paths2: BTreeSet<String> =
+                    ["linkdir/evil.py".to_string()].into_iter().collect();
+                let delta2 = idx.refresh_paths(&paths2).unwrap();
+                assert!(
+                    !delta2
+                        .project
+                        .files
+                        .iter()
+                        .any(|f| f.relative_path == "linkdir/evil.py"),
+                    "path through symlinked dir must not be indexed"
+                );
+            }
+        }
+        #[cfg(windows)]
+        {
+            let outside_sub = outside_dir.path().join("sub");
+            let _ = fs::create_dir_all(&outside_sub);
+            let _ = fs::write(outside_sub.join("evil.py"), b"evil");
+            let link_dir = tmp.path().join("linkdir");
+            let res2 = std::os::windows::fs::symlink_dir(&outside_sub, &link_dir);
+            if res2.is_ok() {
+                let paths2: BTreeSet<String> =
+                    ["linkdir/evil.py".to_string()].into_iter().collect();
+                let delta2 = idx.refresh_paths(&paths2).unwrap();
+                assert!(!delta2
+                    .project
+                    .files
+                    .iter()
+                    .any(|f| f.relative_path == "linkdir/evil.py"));
+            }
+        }
     }
 }

--- a/crates/context-index/src/discovery.rs
+++ b/crates/context-index/src/discovery.rs
@@ -192,10 +192,10 @@ impl ProjectIndex {
 
         for rel in paths {
             let norm = normalize_rel_path(rel)?;
-            let old = match files.iter().position(|f| f.relative_path == norm) {
-                Some(pos) => Some(files.remove(pos)),
-                None => None,
-            };
+            let old = files
+                .iter()
+                .position(|f| f.relative_path == norm)
+                .map(|pos| files.remove(pos));
             let mut scratch = ScanStats::default();
             if let Some(new) = make_record(&self.root, &norm, true, &mut scratch) {
                 let is_changed = match &old {
@@ -334,8 +334,10 @@ fn make_record(
 
 /// Recompute aggregate scan stats from the final file vector.
 fn recompute_stats(files: &[FileRecord]) -> ScanStats {
-    let mut stats = ScanStats::default();
-    stats.discovered = files.len();
+    let mut stats = ScanStats {
+        discovered: files.len(),
+        ..Default::default()
+    };
     for f in files {
         stats.total_bytes += f.size_bytes;
         match f.kind {

--- a/crates/context-index/src/discovery.rs
+++ b/crates/context-index/src/discovery.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -79,6 +80,14 @@ pub struct ProjectIndex {
     pub stats: ScanStats,
 }
 
+/// Result of refreshing a project index for a set of dirty paths.
+#[derive(Debug, Clone)]
+pub struct ProjectIndexDelta {
+    pub project: ProjectIndex,
+    pub changed_files: Vec<String>,
+    pub deleted_files: Vec<String>,
+}
+
 impl ProjectIndex {
     /// Discover, classify, hash (streaming, 10 MB limit).
     pub fn discover(root: &ProjectRoot) -> Result<Self, ContextError> {
@@ -129,63 +138,9 @@ impl ProjectIndex {
                 .map(|p| p.to_string_lossy().replace('\\', "/"))
                 .unwrap_or_else(|_| path.to_string_lossy().to_string());
 
-            // Engine-internal check
-            if is_engine_internal(&rel, root_path) {
-                stats.skipped_generated += 1;
-                continue;
+            if let Some(record) = make_record(root_path, &rel, do_hash, &mut stats) {
+                files.push(record);
             }
-
-            // Also skip via is_ignored (DEFAULT_IGNORES) for discovery
-            // For now, rely on WalkBuilder + is_engine_internal; additional filtering happens in exact_search.
-
-            let kind = classify_file(Path::new(&rel));
-            // Skip generated for discovery? Keep but mark.
-            if kind == FileKind::Generated {
-                stats.skipped_generated += 1;
-                // Still record? For R1, we skip generated from filesVec to keep memory small.
-                continue;
-            }
-
-            let meta = match std::fs::metadata(path) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            let size = meta.len();
-            stats.total_bytes += size;
-            match kind {
-                FileKind::Source => stats.source += 1,
-                FileKind::Test => stats.test += 1,
-                FileKind::Doc => stats.doc += 1,
-                FileKind::Config => stats.config += 1,
-                FileKind::Build => stats.build += 1,
-                FileKind::Generated => stats.generated += 1,
-                FileKind::Unknown => stats.unknown += 1,
-            }
-
-            // Binary safety: only hash supported kinds and size < 10 MB, and not binary
-            let hash = if do_hash && is_text_searchable(&rel, kind) && size <= 10 * 1024 * 1024 {
-                match hash_file(path) {
-                    Ok(h) => Some(h),
-                    Err(e) => {
-                        stats.hash_errors += 1;
-                        tracing::debug!(file = %rel, error = %e, "hash skipped");
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-
-            let modified = meta.modified().ok();
-
-            files.push(FileRecord {
-                relative_path: rel,
-                absolute_path: path.to_path_buf(),
-                kind,
-                size_bytes: size,
-                modified_time: modified,
-                content_hash: hash,
-            });
         }
 
         stats.discovered = files.len();
@@ -225,6 +180,149 @@ impl ProjectIndex {
             .iter()
             .find(|f| f.relative_path.to_lowercase() == norm)
     }
+
+    /// Refresh the index for a set of dirty relative paths without a full walk.
+    pub fn refresh_paths(
+        &self,
+        paths: &BTreeSet<String>,
+    ) -> Result<ProjectIndexDelta, ContextError> {
+        let mut files = self.files.clone();
+        let mut changed = Vec::new();
+        let mut deleted = Vec::new();
+
+        for rel in paths {
+            let norm = rel.replace('\\', "/").trim_start_matches("./").to_string();
+            let old = files.iter().find(|f| f.relative_path == norm).cloned();
+            if let Some(pos) = files.iter().position(|f| f.relative_path == norm) {
+                files.remove(pos);
+            }
+            let mut scratch = ScanStats::default();
+            if let Some(new) = make_record(&self.root, &norm, true, &mut scratch) {
+                let is_changed = match &old {
+                    Some(o) => {
+                        o.kind != new.kind
+                            || o.size_bytes != new.size_bytes
+                            || o.modified_time != new.modified_time
+                            || o.content_hash != new.content_hash
+                    }
+                    None => true,
+                };
+                if is_changed {
+                    changed.push(norm.clone());
+                }
+                files.push(new);
+            } else if old.is_some() {
+                deleted.push(norm.clone());
+            }
+        }
+
+        files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+        changed.sort();
+        deleted.sort();
+
+        let stats = recompute_stats(&files);
+
+        Ok(ProjectIndexDelta {
+            project: ProjectIndex {
+                root: self.root.clone(),
+                files,
+                stats,
+            },
+            changed_files: changed,
+            deleted_files: deleted,
+        })
+    }
+}
+
+/// Build a single `FileRecord` from a relative posix path.
+/// Updates `stats` to reflect the record, mirroring the logic in full discovery.
+fn make_record(
+    root_path: &Path,
+    rel: &str,
+    do_hash: bool,
+    stats: &mut ScanStats,
+) -> Option<FileRecord> {
+    let path = root_path.join(rel);
+
+    // Engine-internal check
+    if is_engine_internal(rel, root_path) {
+        stats.skipped_generated += 1;
+        return None;
+    }
+
+    let kind = classify_file(Path::new(rel));
+    // Skip generated for discovery? Keep but mark.
+    if kind == FileKind::Generated {
+        stats.skipped_generated += 1;
+        // Still record? For R1, we skip generated from filesVec to keep memory small.
+        return None;
+    }
+
+    let meta = match std::fs::metadata(&path) {
+        Ok(m) => m,
+        Err(_) => return None,
+    };
+    let size = meta.len();
+    stats.total_bytes += size;
+    match kind {
+        FileKind::Source => stats.source += 1,
+        FileKind::Test => stats.test += 1,
+        FileKind::Doc => stats.doc += 1,
+        FileKind::Config => stats.config += 1,
+        FileKind::Build => stats.build += 1,
+        FileKind::Generated => stats.generated += 1,
+        FileKind::Unknown => stats.unknown += 1,
+    }
+
+    // Binary safety: only hash supported kinds and size < 10 MB, and not binary
+    let hash = if do_hash && is_text_searchable(rel, kind) && size <= 10 * 1024 * 1024 {
+        match hash_file(&path) {
+            Ok(h) => Some(h),
+            Err(e) => {
+                stats.hash_errors += 1;
+                tracing::debug!(file = %rel, error = %e, "hash skipped");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let modified = meta.modified().ok();
+
+    Some(FileRecord {
+        relative_path: rel.to_string(),
+        absolute_path: path,
+        kind,
+        size_bytes: size,
+        modified_time: modified,
+        content_hash: hash,
+    })
+}
+
+/// Recompute aggregate scan stats from the final file vector.
+fn recompute_stats(files: &[FileRecord]) -> ScanStats {
+    let mut stats = ScanStats::default();
+    stats.discovered = files.len();
+    for f in files {
+        stats.total_bytes += f.size_bytes;
+        match f.kind {
+            FileKind::Source => stats.source += 1,
+            FileKind::Test => stats.test += 1,
+            FileKind::Doc => stats.doc += 1,
+            FileKind::Config => stats.config += 1,
+            FileKind::Build => stats.build += 1,
+            FileKind::Generated => stats.generated += 1,
+            FileKind::Unknown => stats.unknown += 1,
+        }
+        if f.content_hash.is_none()
+            && is_text_searchable(&f.relative_path, f.kind)
+            && f.size_bytes <= 10 * 1024 * 1024
+        {
+            stats.hash_errors += 1;
+        }
+    }
+    stats
 }
 
 /// Whether file is text-searchable for exact search.
@@ -281,6 +379,7 @@ fn is_text_searchable(rel: &str, kind: FileKind) -> bool {
 mod tests {
     use super::*;
     use crate::project_root::ProjectRoot;
+    use std::collections::BTreeSet;
     use std::fs;
     use tempfile::TempDir;
 
@@ -319,5 +418,187 @@ mod tests {
         let found = idx.find_by_filename("go.mod");
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].relative_path, "go.mod");
+    }
+
+    #[test]
+    fn refresh_paths_create() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        fs::write(tmp.path().join("b.py"), b"world").unwrap();
+        let paths: BTreeSet<String> = ["b.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "b.py"));
+        assert_eq!(delta.changed_files, vec!["b.py"]);
+        assert!(delta.deleted_files.is_empty());
+        assert!(delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "a.py"));
+    }
+
+    #[test]
+    fn refresh_paths_modify() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let old_hash = idx
+            .files
+            .iter()
+            .find(|f| f.relative_path == "a.py")
+            .unwrap()
+            .content_hash
+            .clone();
+        fs::write(tmp.path().join("a.py"), b"hello world").unwrap();
+        let paths: BTreeSet<String> = ["a.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        let new_hash = delta
+            .project
+            .files
+            .iter()
+            .find(|f| f.relative_path == "a.py")
+            .unwrap()
+            .content_hash
+            .clone();
+        assert_ne!(old_hash, new_hash);
+        assert_eq!(delta.changed_files, vec!["a.py"]);
+        assert!(delta.deleted_files.is_empty());
+    }
+
+    #[test]
+    fn refresh_paths_delete() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        fs::write(tmp.path().join("b.py"), b"world").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        fs::remove_file(tmp.path().join("a.py")).unwrap();
+        let paths: BTreeSet<String> = ["a.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(!delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "a.py"));
+        assert!(delta.changed_files.is_empty());
+        assert_eq!(delta.deleted_files, vec!["a.py"]);
+        assert!(delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "b.py"));
+    }
+
+    #[test]
+    fn refresh_paths_unchanged() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let paths: BTreeSet<String> = ["a.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(delta.changed_files.is_empty());
+        assert!(delta.deleted_files.is_empty());
+    }
+
+    #[test]
+    fn refresh_paths_unrelated_stable() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        fs::write(tmp.path().join("b.py"), b"world").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        let old_b = idx
+            .files
+            .iter()
+            .find(|f| f.relative_path == "b.py")
+            .unwrap()
+            .clone();
+        fs::write(tmp.path().join("a.py"), b"hello world").unwrap();
+        let paths: BTreeSet<String> = ["a.py".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        let new_b = delta
+            .project
+            .files
+            .iter()
+            .find(|f| f.relative_path == "b.py")
+            .unwrap();
+        assert_eq!(old_b.content_hash, new_b.content_hash);
+        assert_eq!(old_b.size_bytes, new_b.size_bytes);
+        assert_eq!(old_b.modified_time, new_b.modified_time);
+        assert_eq!(old_b.kind, new_b.kind);
+    }
+
+    #[test]
+    fn refresh_paths_sorted() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("z.py"), b"z").unwrap();
+        fs::write(tmp.path().join("a.py"), b"a").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        fs::remove_file(tmp.path().join("z.py")).unwrap();
+        fs::write(tmp.path().join("m.py"), b"m").unwrap();
+        let paths: BTreeSet<String> = ["z.py".to_string(), "m.py".to_string()]
+            .into_iter()
+            .collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert_eq!(delta.changed_files, vec!["m.py"]);
+        assert_eq!(delta.deleted_files, vec!["z.py"]);
+    }
+
+    #[test]
+    fn refresh_paths_excludes_generated_internal() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        fs::create_dir_all(tmp.path().join("target/debug")).unwrap();
+        fs::write(tmp.path().join("target/debug/foo"), b"bin").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        // New generated file must not appear.
+        fs::write(tmp.path().join("target/debug/bar"), b"bin2").unwrap();
+        let paths: BTreeSet<String> = ["target/debug/bar".to_string()].into_iter().collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert!(!delta
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "target/debug/bar"));
+        assert!(delta.changed_files.is_empty());
+        assert!(delta.deleted_files.is_empty());
+        // Unrelated existing excludes remain absent after a separate refresh.
+        fs::write(tmp.path().join("a.py"), b"hello world").unwrap();
+        let paths2: BTreeSet<String> = ["a.py".to_string()].into_iter().collect();
+        let delta2 = idx.refresh_paths(&paths2).unwrap();
+        assert!(!delta2
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path.contains("target/")));
+    }
+
+    #[test]
+    fn refresh_paths_recomputes_stats() {
+        let tmp = TempDir::new().unwrap();
+        let root = ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        fs::write(tmp.path().join("a.py"), b"hello").unwrap();
+        fs::write(tmp.path().join("b.md"), b"# doc").unwrap();
+        let idx = ProjectIndex::discover(&root).unwrap();
+        fs::remove_file(tmp.path().join("b.md")).unwrap();
+        fs::write(tmp.path().join("c.rs"), b"fn main() {}").unwrap();
+        let paths: BTreeSet<String> = ["b.md".to_string(), "c.rs".to_string()]
+            .into_iter()
+            .collect();
+        let delta = idx.refresh_paths(&paths).unwrap();
+        assert_eq!(delta.project.stats.discovered, 2);
+        assert_eq!(delta.project.stats.source, 2);
+        assert_eq!(delta.project.stats.doc, 0);
+        assert_eq!(delta.project.stats.total_bytes, 5 + 12);
     }
 }

--- a/crates/context-index/src/watcher.rs
+++ b/crates/context-index/src/watcher.rs
@@ -543,10 +543,6 @@ fn event_kind_implies_unknown(kind: &EventKind) -> bool {
     )
 }
 
-fn looks_like_file(path: &Path) -> bool {
-    path.extension().is_some()
-}
-
 fn is_ignore_control_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
@@ -604,12 +600,7 @@ fn classify_event(root: &Path, event: &Event) -> EventAction {
             event.kind,
             EventKind::Remove(RemoveKind::Any) | EventKind::Remove(RemoveKind::Other)
         ) {
-            if looks_like_file(p) {
-                rels.push(rel);
-            } else {
-                return EventAction::MarkUnknown;
-            }
-            continue;
+            return EventAction::MarkUnknown;
         }
         rels.push(rel);
     }
@@ -1126,15 +1117,14 @@ mod tests {
     fn classify_vanished_generic_remove_is_unknown() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
-        // File with extension via generic remove remains path-local (not unknown)
-        let vanished = root.join("src/gone.rs");
+        // Ambiguous generic remove must be Unknown even for file-like names
+        let vanished = root.join("foo.rs");
         let event = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(vanished);
         assert_eq!(
             classify_event(root, &event),
-            EventAction::MarkPaths(vec!["src/gone.rs".to_string()]),
-            "generic Remove(Any) for file with extension must remain path-local"
+            EventAction::MarkUnknown,
+            "generic Remove(Any) must be MarkUnknown even for foo.rs"
         );
-        // Directory-like path without extension via generic remove is ambiguous -> Unknown
         let vanished2 = root.join("src/old_dir");
         let event2 = Event::new(EventKind::Remove(RemoveKind::Other)).add_path(vanished2);
         assert_eq!(classify_event(root, &event2), EventAction::MarkUnknown);
@@ -1142,6 +1132,39 @@ mod tests {
         let ignored = root.join(".context/index/db");
         let event3 = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(ignored);
         assert_eq!(classify_event(root, &event3), EventAction::Noop);
+    }
+
+    #[test]
+    fn classify_dotted_dir_ambiguous_remove_is_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        // Dotted directory names must not be inferred as files
+        let dir1 = root.join("src/v1.2");
+        let event1 = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(dir1);
+        assert_eq!(
+            classify_event(root, &event1),
+            EventAction::MarkUnknown,
+            "ambiguous Remove(Any) for src/v1.2 must be MarkUnknown"
+        );
+        let dir2 = root.join("packages/foo.bar");
+        let event2 = Event::new(EventKind::Remove(RemoveKind::Other)).add_path(dir2);
+        assert_eq!(
+            classify_event(root, &event2),
+            EventAction::MarkUnknown,
+            "ambiguous Remove(Other) for packages/foo.bar must be MarkUnknown"
+        );
+        // Also ensure a file-like path via ambiguous is still Unknown
+        let file_like = root.join("src/v1.2/a.rs");
+        // normal file removal via explicit File kind is path-local, but ambiguous for the dir itself is Unknown
+        // Verify the dir case dominates
+        assert_eq!(
+            classify_event(
+                root,
+                &Event::new(EventKind::Remove(RemoveKind::Any)).add_path(root.join("src/v1.2"))
+            ),
+            EventAction::MarkUnknown
+        );
+        let _ = file_like;
     }
 
     #[test]

--- a/crates/context-index/src/watcher.rs
+++ b/crates/context-index/src/watcher.rs
@@ -532,6 +532,61 @@ fn is_ignore_control_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Action derived from a filesystem event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventAction {
+    Noop,
+    MarkUnknown,
+    MarkPaths(Vec<String>),
+}
+
+impl EventAction {
+    fn apply(&self, tracker: &DirtyTracker) {
+        match self {
+            EventAction::Noop => {}
+            EventAction::MarkUnknown => {
+                tracker.mark_unknown();
+            }
+            EventAction::MarkPaths(paths) => {
+                tracker.mark_paths(paths.clone());
+            }
+        }
+    }
+}
+
+/// Classify a notify event relative to a repository root.
+///
+/// Per-path order: normalize; skip ignored; if ignore-control then MarkUnknown;
+/// if nonignored folder kind or path is a directory then MarkUnknown;
+/// otherwise collect the regular relative paths. Empty/all-ignored -> Noop.
+fn classify_event(root: &Path, event: &Event) -> EventAction {
+    if event.need_rescan() {
+        return EventAction::MarkUnknown;
+    }
+    let mut rels = Vec::new();
+    for p in &event.paths {
+        let rel = match normalize_rel(root, p) {
+            Some(r) => r,
+            None => return EventAction::MarkUnknown,
+        };
+        if is_ignored(&rel) {
+            continue;
+        }
+        if is_ignore_control_file(p) {
+            return EventAction::MarkUnknown;
+        }
+        if event_kind_implies_unknown(&event.kind) || p.is_dir() {
+            return EventAction::MarkUnknown;
+        }
+        rels.push(rel);
+    }
+    if rels.is_empty() {
+        EventAction::Noop
+    } else {
+        EventAction::MarkPaths(rels)
+    }
+}
+
 /// Lightweight, mark-only repository watcher.
 ///
 /// The notify callback records normalized relative paths in a `DirtyTracker`. It performs
@@ -551,34 +606,7 @@ impl RepositoryWatcher {
         let mut watcher =
             notify::recommended_watcher(move |res: Result<Event, notify::Error>| match res {
                 Ok(event) => {
-                    if event_kind_implies_unknown(&event.kind) {
-                        tracker_cb.mark_unknown();
-                        return;
-                    }
-                    let mut rels = Vec::new();
-                    let mut unknown = false;
-                    for p in &event.paths {
-                        if p.is_dir() {
-                            unknown = true;
-                            break;
-                        }
-                        if is_ignore_control_file(p) {
-                            unknown = true;
-                            break;
-                        }
-                        match normalize_rel(&root_cb, p) {
-                            Some(rel) => rels.push(rel),
-                            None => {
-                                unknown = true;
-                                break;
-                            }
-                        }
-                    }
-                    if unknown {
-                        tracker_cb.mark_unknown();
-                    } else if !rels.is_empty() {
-                        tracker_cb.mark_paths(rels);
-                    }
+                    classify_event(&root_cb, &event).apply(&tracker_cb);
                 }
                 Err(_) => {
                     tracker_cb.mark_unknown();
@@ -606,6 +634,7 @@ impl RepositoryWatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use notify::event::{DataChange, ModifyKind};
     use tempfile::TempDir;
 
     #[test]
@@ -857,6 +886,112 @@ mod tests {
             !event_kind_implies_unknown(&EventKind::Remove(RemoveKind::File)),
             "Remove(File) should not imply Unknown"
         );
+    }
+
+    #[test]
+    fn classify_ignored_context_folder_create_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let context_dir = root.join(".context");
+        std::fs::create_dir_all(&context_dir).unwrap();
+        let event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(context_dir);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::Noop,
+            "creating the runtime .context directory must not dirty state"
+        );
+    }
+
+    #[test]
+    fn classify_ignored_context_folder_remove_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let context_dir = root.join(".context");
+        // Path no longer exists, as it would be for a Remove(Folder) event.
+        let event = Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(context_dir);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::Noop,
+            "removing the runtime .context directory must not dirty state"
+        );
+    }
+
+    #[test]
+    fn classify_ignored_context_db_modify_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let db = root.join(".context/index/structural.db");
+        std::fs::create_dir_all(db.parent().unwrap()).unwrap();
+        std::fs::write(&db, b"").unwrap();
+        let event =
+            Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content))).add_path(db);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::Noop,
+            "modifying the runtime structural DB must not dirty state"
+        );
+    }
+
+    #[test]
+    fn classify_nonignored_folder_remove_is_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let src_dir = root.join("src");
+        // Directory has been removed, so it does not exist.
+        let event = Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(src_dir);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::MarkUnknown,
+            "removing a nonignored directory must mark Unknown"
+        );
+    }
+
+    #[test]
+    fn classify_regular_file_modify_is_paths() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let file = root.join("src/main.rs");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, b"fn main() {}").unwrap();
+        let event =
+            Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content))).add_path(file);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::MarkPaths(vec!["src/main.rs".to_string()]),
+            "modifying a regular nonignored file must record its relative path"
+        );
+    }
+
+    #[test]
+    fn classify_all_ignored_paths_leaves_tracker_unchanged() {
+        let tracker = DirtyTracker::new(10);
+        let before = tracker.snapshot();
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let event = Event::new(EventKind::Create(CreateKind::Folder))
+            .add_path(root.join(".context"))
+            .add_path(root.join(".git/objects"));
+        let action = classify_event(root, &event);
+        assert_eq!(
+            action,
+            EventAction::Noop,
+            "all-ignored event must produce Noop"
+        );
+
+        // Applying Noop must not mutate tracker state/epoch.
+        match action {
+            EventAction::MarkPaths(rels) => {
+                tracker.mark_paths(rels);
+            }
+            EventAction::MarkUnknown => {
+                tracker.mark_unknown();
+            }
+            EventAction::Noop => {}
+        }
+        let after = tracker.snapshot();
+        assert_eq!(after.state, before.state);
+        assert_eq!(after.epoch, before.epoch, "Noop must not bump epoch");
     }
 
     #[test]

--- a/crates/context-index/src/watcher.rs
+++ b/crates/context-index/src/watcher.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use notify::{
-    event::{CreateKind, RemoveKind},
+    event::{CreateKind, ModifyKind, RemoveKind},
     Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher,
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -71,7 +71,6 @@ const BOUNDED_CAP: usize = 512;
 const IGNORED_DIRS: &[&str] = &[
     ".git/",
     ".context/",
-    ".opencode/",
     "target/",
     "node_modules/",
     "dist/",
@@ -83,8 +82,18 @@ const IGNORED_DIRS: &[&str] = &[
     "coverage/",
 ];
 
+fn is_opencode_index_ignored(lower: &str) -> bool {
+    lower == ".opencode/index"
+        || lower.starts_with(".opencode/index/")
+        || lower.contains("/.opencode/index/")
+        || lower.ends_with("/.opencode/index")
+}
+
 fn is_ignored(rel: &str) -> bool {
     let lower = rel.to_lowercase().replace('\\', "/");
+    if is_opencode_index_ignored(&lower) {
+        return true;
+    }
     for pat in IGNORED_DIRS {
         if lower.starts_with(pat)
             || lower.contains(&format!("/{}", pat))
@@ -528,7 +537,11 @@ impl DirtyTracker {
 fn event_kind_implies_unknown(kind: &EventKind) -> bool {
     matches!(
         kind,
-        EventKind::Create(CreateKind::Folder) | EventKind::Remove(RemoveKind::Folder)
+        EventKind::Create(CreateKind::Folder)
+            | EventKind::Remove(RemoveKind::Folder)
+            | EventKind::Modify(ModifyKind::Name(_))
+            | EventKind::Remove(RemoveKind::Any)
+            | EventKind::Remove(RemoveKind::Other)
     )
 }
 
@@ -1020,6 +1033,118 @@ mod tests {
             EventAction::MarkUnknown,
             "escape via '..' must classify as Unknown"
         );
+    }
+
+    #[test]
+    fn classify_opencode_settings_is_paths() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let file = root.join(".opencode/settings.json");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, b"{}").unwrap();
+        let event =
+            Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content))).add_path(file);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::MarkPaths(vec![".opencode/settings.json".to_string()]),
+            ".opencode/settings.json must not be ignored"
+        );
+        assert!(!is_ignored(".opencode/settings.json"));
+    }
+
+    #[test]
+    fn classify_opencode_index_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let file = root.join(".opencode/index/structural.db");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, b"").unwrap();
+        let event = Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content)))
+            .add_path(file.clone());
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::Noop,
+            ".opencode/index and descendants must be ignored"
+        );
+        assert!(is_ignored(".opencode/index/structural.db"));
+        assert!(is_ignored(".opencode/index"));
+        // sibling file under .opencode/index subdir
+        let file2 = root.join(".opencode/index/a/b.rs");
+        let event2 = Event::new(EventKind::Create(CreateKind::File)).add_path(file2);
+        assert_eq!(classify_event(root, &event2), EventAction::Noop);
+    }
+
+    #[test]
+    fn classify_vanished_generic_rename_is_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let vanished = root.join("src/renamed.rs");
+        // do not create file — vanished
+        let event = Event::new(EventKind::Modify(ModifyKind::Name(
+            notify::event::RenameMode::Any,
+        )))
+        .add_path(vanished);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::MarkUnknown,
+            "generic ModifyKind::Name for vanished path must be MarkUnknown"
+        );
+        // also Both variant
+        let vanished2 = root.join("src/other.rs");
+        let event2 = Event::new(EventKind::Modify(ModifyKind::Name(
+            notify::event::RenameMode::Both,
+        )))
+        .add_path(vanished2);
+        assert_eq!(classify_event(root, &event2), EventAction::MarkUnknown);
+        // ignored path with rename must stay Noop
+        let ignored = root.join(".opencode/index/foo.db");
+        let event3 = Event::new(EventKind::Modify(ModifyKind::Name(
+            notify::event::RenameMode::Any,
+        )))
+        .add_path(ignored);
+        assert_eq!(
+            classify_event(root, &event3),
+            EventAction::Noop,
+            "ignored paths must remain Noop even for rename"
+        );
+    }
+
+    #[test]
+    fn classify_vanished_generic_remove_is_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let vanished = root.join("src/gone.rs");
+        let event = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(vanished);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::MarkUnknown,
+            "generic Remove(Any) for vanished path must be MarkUnknown"
+        );
+        let vanished2 = root.join("src/gone2.rs");
+        let event2 = Event::new(EventKind::Remove(RemoveKind::Other)).add_path(vanished2);
+        assert_eq!(classify_event(root, &event2), EventAction::MarkUnknown);
+        // ignored generic remove stays Noop
+        let ignored = root.join(".context/index/db");
+        let event3 = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(ignored);
+        assert_eq!(classify_event(root, &event3), EventAction::Noop);
+    }
+
+    #[test]
+    fn classify_exact_file_remove_is_paths() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let vanished = root.join("src/deleted.rs");
+        // exact file remove for vanished path remains path-local
+        let event = Event::new(EventKind::Remove(RemoveKind::File)).add_path(vanished);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::MarkPaths(vec!["src/deleted.rs".to_string()]),
+            "exact Remove(File) must remain path-local even when vanished"
+        );
+        // exact folder remove remains unknown (coverage)
+        let vanished_dir = root.join("src/subdir");
+        let event2 = Event::new(EventKind::Remove(RemoveKind::Folder)).add_path(vanished_dir);
+        assert_eq!(classify_event(root, &event2), EventAction::MarkUnknown);
     }
 
     #[test]

--- a/crates/context-index/src/watcher.rs
+++ b/crates/context-index/src/watcher.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -370,6 +370,226 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Mark-only dirty state. `Unknown` means the watcher cannot tell which paths changed.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum DirtyState {
+    #[default]
+    Clean,
+    Paths(BTreeSet<String>),
+    Unknown,
+}
+
+/// A snapshot of dirty state plus its epoch. The epoch protects acknowledgement from
+/// clearing changes that arrived after the snapshot was taken.
+#[derive(Debug, Clone)]
+pub struct DirtySnapshot {
+    pub state: DirtyState,
+    pub epoch: u64,
+}
+
+#[derive(Debug)]
+struct DirtyTrackerInner {
+    state: DirtyState,
+    epoch: u64,
+    capacity: usize,
+}
+
+/// Bounded, epoch-protected dirty tracker.
+///
+/// - `snapshot` returns the current state and epoch without changing either.
+/// - `acknowledge(epoch)` clears the state only if the epoch has not moved on.
+/// - A poisoned lock always reports `Unknown` so the tracker never falsely claims cleanliness.
+#[derive(Debug, Clone)]
+pub struct DirtyTracker {
+    inner: Arc<std::sync::Mutex<DirtyTrackerInner>>,
+}
+
+impl DirtyTracker {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(DirtyTrackerInner {
+                state: DirtyState::Clean,
+                epoch: 0,
+                capacity,
+            })),
+        }
+    }
+
+    pub fn mark_paths(&self, paths: impl IntoIterator<Item = String>) -> DirtySnapshot {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(_) => {
+                return DirtySnapshot {
+                    state: DirtyState::Unknown,
+                    epoch: 0,
+                }
+            }
+        };
+
+        // Once unknown, more precise path information is intentionally lost.
+        if guard.state == DirtyState::Unknown {
+            guard.epoch = guard.epoch.wrapping_add(1);
+            return DirtySnapshot {
+                state: DirtyState::Unknown,
+                epoch: guard.epoch,
+            };
+        }
+
+        let mut set = match std::mem::take(&mut guard.state) {
+            DirtyState::Clean => BTreeSet::new(),
+            DirtyState::Paths(s) => s,
+            DirtyState::Unknown => BTreeSet::new(),
+        };
+
+        for p in paths {
+            set.insert(p);
+        }
+
+        guard.state = if set.len() > guard.capacity {
+            DirtyState::Unknown
+        } else {
+            DirtyState::Paths(set)
+        };
+        guard.epoch = guard.epoch.wrapping_add(1);
+        DirtySnapshot {
+            state: guard.state.clone(),
+            epoch: guard.epoch,
+        }
+    }
+
+    pub fn mark_unknown(&self) -> DirtySnapshot {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(_) => {
+                return DirtySnapshot {
+                    state: DirtyState::Unknown,
+                    epoch: 0,
+                }
+            }
+        };
+        guard.state = DirtyState::Unknown;
+        guard.epoch = guard.epoch.wrapping_add(1);
+        DirtySnapshot {
+            state: guard.state.clone(),
+            epoch: guard.epoch,
+        }
+    }
+
+    pub fn snapshot(&self) -> DirtySnapshot {
+        match self.inner.lock() {
+            Ok(guard) => DirtySnapshot {
+                state: guard.state.clone(),
+                epoch: guard.epoch,
+            },
+            Err(_) => DirtySnapshot {
+                state: DirtyState::Unknown,
+                epoch: 0,
+            },
+        }
+    }
+
+    pub fn acknowledge(&self, epoch: u64) -> DirtySnapshot {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(_) => {
+                return DirtySnapshot {
+                    state: DirtyState::Unknown,
+                    epoch: 0,
+                }
+            }
+        };
+
+        if guard.state == DirtyState::Unknown {
+            return DirtySnapshot {
+                state: DirtyState::Unknown,
+                epoch: guard.epoch,
+            };
+        }
+
+        if epoch == guard.epoch {
+            guard.state = DirtyState::Clean;
+        }
+        DirtySnapshot {
+            state: guard.state.clone(),
+            epoch: guard.epoch,
+        }
+    }
+}
+
+fn is_ignore_control_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == ".gitignore" || n == ".ignore")
+        .unwrap_or(false)
+}
+
+/// Lightweight, mark-only repository watcher.
+///
+/// The notify callback records normalized relative paths in a `DirtyTracker`. It performs
+/// no SQLite work, no parsing/hashing/embedding, and no async spawning.
+pub struct RepositoryWatcher {
+    root: PathBuf,
+    tracker: DirtyTracker,
+    _watcher: RecommendedWatcher,
+}
+
+impl RepositoryWatcher {
+    pub fn new(root: PathBuf) -> Result<Self> {
+        let tracker = DirtyTracker::new(BOUNDED_CAP);
+        let tracker_cb = tracker.clone();
+        let root_cb = root.clone();
+
+        let mut watcher =
+            notify::recommended_watcher(move |res: Result<Event, notify::Error>| match res {
+                Ok(event) => {
+                    let mut rels = Vec::new();
+                    let mut unknown = false;
+                    for p in &event.paths {
+                        if p.is_dir() {
+                            unknown = true;
+                            break;
+                        }
+                        if is_ignore_control_file(p) {
+                            unknown = true;
+                            break;
+                        }
+                        match normalize_rel(&root_cb, p) {
+                            Some(rel) => rels.push(rel),
+                            None => {
+                                unknown = true;
+                                break;
+                            }
+                        }
+                    }
+                    if unknown {
+                        tracker_cb.mark_unknown();
+                    } else if !rels.is_empty() {
+                        tracker_cb.mark_paths(rels);
+                    }
+                }
+                Err(_) => {
+                    tracker_cb.mark_unknown();
+                }
+            })?;
+
+        watcher.watch(&root, RecursiveMode::Recursive)?;
+
+        Ok(Self {
+            root,
+            tracker,
+            _watcher: watcher,
+        })
+    }
+
+    pub fn tracker(&self) -> &DirtyTracker {
+        &self.tracker
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -473,6 +693,121 @@ mod tests {
         // No missing files
         assert_eq!(stats.files_parsed + stats.files_skipped, 10);
         w.shutdown().await;
+        Ok(())
+    }
+
+    #[test]
+    fn dirty_ack_does_not_lose_same_path_event_after_snapshot() {
+        let tracker = DirtyTracker::new(10);
+        tracker.mark_paths(["src/main.rs".to_string()]);
+        let snap = tracker.snapshot();
+        assert_eq!(
+            snap.state,
+            DirtyState::Paths(BTreeSet::from(["src/main.rs".to_string()]))
+        );
+        let epoch = snap.epoch;
+
+        // Same-path event arrives after snapshot.
+        tracker.mark_paths(["src/main.rs".to_string()]);
+        let ack = tracker.acknowledge(epoch);
+
+        // Acknowledging the old epoch must not drop the later same-path event.
+        assert_ne!(
+            ack.state,
+            DirtyState::Clean,
+            "ack of old epoch after a new event must not clear state"
+        );
+        assert!(
+            matches!(ack.state, DirtyState::Paths(_)),
+            "same-path event after snapshot must be preserved"
+        );
+    }
+
+    #[test]
+    fn dirty_capacity_overflow_becomes_unknown() {
+        let tracker = DirtyTracker::new(2);
+        tracker.mark_paths(["a.rs".to_string(), "b.rs".to_string()]);
+        assert!(
+            !matches!(tracker.snapshot().state, DirtyState::Unknown),
+            "state under capacity should remain Paths"
+        );
+
+        tracker.mark_paths(["c.rs".to_string()]);
+        assert_eq!(
+            tracker.snapshot().state,
+            DirtyState::Unknown,
+            "exceeding capacity must collapse to Unknown"
+        );
+    }
+
+    #[test]
+    fn dirty_unchanged_epoch_acknowledges_to_clean() {
+        let tracker = DirtyTracker::new(10);
+        tracker.mark_paths(["src/main.rs".to_string()]);
+        let snap = tracker.snapshot();
+        let epoch = snap.epoch;
+        assert!(
+            matches!(snap.state, DirtyState::Paths(_)),
+            "state should be dirty before ack"
+        );
+
+        let ack = tracker.acknowledge(epoch);
+        assert_eq!(
+            ack.state,
+            DirtyState::Clean,
+            "acknowledging the current unchanged epoch must clear to Clean"
+        );
+    }
+
+    fn wait_for_state(
+        tracker: &DirtyTracker,
+        timeout: Duration,
+        predicate: impl Fn(&DirtyState) -> bool,
+    ) -> Option<DirtySnapshot> {
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout {
+            let snap = tracker.snapshot();
+            if predicate(&snap.state) {
+                return Some(snap);
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        None
+    }
+
+    #[test]
+    fn dirty_watcher_classifies_source_and_gitignore() -> Result<()> {
+        let tmp = TempDir::new()?;
+        let root = tmp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".git"))?;
+        std::fs::create_dir_all(root.join("src"))?;
+
+        let watcher = RepositoryWatcher::new(root.clone())?;
+        assert_eq!(watcher.root(), root.as_path());
+
+        // Regular source modification records its relative path.
+        std::fs::write(root.join("src/main.rs"), "fn main() {}\n")?;
+        let snap = wait_for_state(watcher.tracker(), Duration::from_millis(1000), |s| {
+            matches!(s, DirtyState::Paths(_))
+        });
+        assert!(snap.is_some(), "source change should be recorded");
+        assert_eq!(
+            snap.unwrap().state,
+            DirtyState::Paths(BTreeSet::from(["src/main.rs".to_string()]))
+        );
+
+        // Acknowledge so the next event is isolated.
+        let epoch = watcher.tracker().snapshot().epoch;
+        watcher.tracker().acknowledge(epoch);
+        assert_eq!(watcher.tracker().snapshot().state, DirtyState::Clean);
+
+        // Changing .gitignore collapses state to Unknown.
+        std::fs::write(root.join(".gitignore"), "target/\n")?;
+        let snap = wait_for_state(watcher.tracker(), Duration::from_millis(1000), |s| {
+            *s == DirtyState::Unknown
+        });
+        assert!(snap.is_some(), ".gitignore change should record Unknown");
+
         Ok(())
     }
 }

--- a/crates/context-index/src/watcher.rs
+++ b/crates/context-index/src/watcher.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
+use notify::{
+    event::{CreateKind, RemoveKind},
+    Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher,
+};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -416,6 +419,12 @@ impl DirtyTracker {
     }
 
     pub fn mark_paths(&self, paths: impl IntoIterator<Item = String>) -> DirtySnapshot {
+        let paths: Vec<String> = paths.into_iter().collect();
+        if paths.is_empty() {
+            // ponytail: true no-op; do not bump epoch or move Clean -> Paths(empty).
+            return self.snapshot();
+        }
+
         let mut guard = match self.inner.lock() {
             Ok(g) => g,
             Err(_) => {
@@ -499,13 +508,6 @@ impl DirtyTracker {
             }
         };
 
-        if guard.state == DirtyState::Unknown {
-            return DirtySnapshot {
-                state: DirtyState::Unknown,
-                epoch: guard.epoch,
-            };
-        }
-
         if epoch == guard.epoch {
             guard.state = DirtyState::Clean;
         }
@@ -516,10 +518,17 @@ impl DirtyTracker {
     }
 }
 
+fn event_kind_implies_unknown(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(CreateKind::Folder) | EventKind::Remove(RemoveKind::Folder)
+    )
+}
+
 fn is_ignore_control_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
-        .map(|n| n == ".gitignore" || n == ".ignore")
+        .map(|n| n == ".gitignore" || n == ".ignore" || n == ".opencodeignore")
         .unwrap_or(false)
 }
 
@@ -542,6 +551,10 @@ impl RepositoryWatcher {
         let mut watcher =
             notify::recommended_watcher(move |res: Result<Event, notify::Error>| match res {
                 Ok(event) => {
+                    if event_kind_implies_unknown(&event.kind) {
+                        tracker_cb.mark_unknown();
+                        return;
+                    }
                     let mut rels = Vec::new();
                     let mut unknown = false;
                     for p in &event.paths {
@@ -773,6 +786,77 @@ mod tests {
             std::thread::sleep(Duration::from_millis(20));
         }
         None
+    }
+
+    #[test]
+    fn dirty_ack_current_epoch_clears_unknown_stale_cannot() {
+        let tracker = DirtyTracker::new(10);
+        tracker.mark_unknown();
+        let snap = tracker.snapshot();
+        assert_eq!(snap.state, DirtyState::Unknown);
+        let epoch = snap.epoch;
+
+        // Current unchanged epoch clears Unknown.
+        let ack = tracker.acknowledge(epoch);
+        assert_eq!(ack.state, DirtyState::Clean);
+
+        // A new Unknown event bumps the epoch.
+        tracker.mark_unknown();
+        // Stale epoch cannot clear Unknown.
+        let stale_ack = tracker.acknowledge(epoch);
+        assert_eq!(stale_ack.state, DirtyState::Unknown);
+    }
+
+    #[test]
+    fn dirty_opencodeignore_is_unknown() {
+        assert!(
+            is_ignore_control_file(Path::new("/repo/.opencodeignore")),
+            ".opencodeignore should be an ignore-control file"
+        );
+        assert!(
+            is_ignore_control_file(Path::new(".opencodeignore")),
+            ".opencodeignore base name should match"
+        );
+        assert!(
+            !is_ignore_control_file(Path::new("/repo/main.rs")),
+            "regular files should not match"
+        );
+    }
+
+    #[test]
+    fn dirty_mark_paths_empty_is_noop() {
+        let tracker = DirtyTracker::new(10);
+        let before = tracker.snapshot();
+        assert_eq!(before.state, DirtyState::Clean);
+        assert_eq!(before.epoch, 0);
+
+        let returned = tracker.mark_paths(std::iter::empty::<String>());
+        assert_eq!(returned.state, DirtyState::Clean);
+        assert_eq!(returned.epoch, 0);
+
+        let after = tracker.snapshot();
+        assert_eq!(after.state, DirtyState::Clean);
+        assert_eq!(after.epoch, 0, "empty mark_paths must not bump epoch");
+    }
+
+    #[test]
+    fn dirty_folder_create_remove_kind_is_unknown() {
+        assert!(
+            event_kind_implies_unknown(&EventKind::Create(CreateKind::Folder)),
+            "Create(Folder) should imply Unknown"
+        );
+        assert!(
+            event_kind_implies_unknown(&EventKind::Remove(RemoveKind::Folder)),
+            "Remove(Folder) should imply Unknown even if the path no longer exists"
+        );
+        assert!(
+            !event_kind_implies_unknown(&EventKind::Create(CreateKind::File)),
+            "Create(File) should not imply Unknown"
+        );
+        assert!(
+            !event_kind_implies_unknown(&EventKind::Remove(RemoveKind::File)),
+            "Remove(File) should not imply Unknown"
+        );
     }
 
     #[test]

--- a/crates/context-index/src/watcher.rs
+++ b/crates/context-index/src/watcher.rs
@@ -540,9 +540,11 @@ fn event_kind_implies_unknown(kind: &EventKind) -> bool {
         EventKind::Create(CreateKind::Folder)
             | EventKind::Remove(RemoveKind::Folder)
             | EventKind::Modify(ModifyKind::Name(_))
-            | EventKind::Remove(RemoveKind::Any)
-            | EventKind::Remove(RemoveKind::Other)
     )
+}
+
+fn looks_like_file(path: &Path) -> bool {
+    path.extension().is_some()
 }
 
 fn is_ignore_control_file(path: &Path) -> bool {
@@ -597,6 +599,17 @@ fn classify_event(root: &Path, event: &Event) -> EventAction {
         }
         if event_kind_implies_unknown(&event.kind) || p.is_dir() {
             return EventAction::MarkUnknown;
+        }
+        if matches!(
+            event.kind,
+            EventKind::Remove(RemoveKind::Any) | EventKind::Remove(RemoveKind::Other)
+        ) {
+            if looks_like_file(p) {
+                rels.push(rel);
+            } else {
+                return EventAction::MarkUnknown;
+            }
+            continue;
         }
         rels.push(rel);
     }
@@ -1113,14 +1126,16 @@ mod tests {
     fn classify_vanished_generic_remove_is_unknown() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
+        // File with extension via generic remove remains path-local (not unknown)
         let vanished = root.join("src/gone.rs");
         let event = Event::new(EventKind::Remove(RemoveKind::Any)).add_path(vanished);
         assert_eq!(
             classify_event(root, &event),
-            EventAction::MarkUnknown,
-            "generic Remove(Any) for vanished path must be MarkUnknown"
+            EventAction::MarkPaths(vec!["src/gone.rs".to_string()]),
+            "generic Remove(Any) for file with extension must remain path-local"
         );
-        let vanished2 = root.join("src/gone2.rs");
+        // Directory-like path without extension via generic remove is ambiguous -> Unknown
+        let vanished2 = root.join("src/old_dir");
         let event2 = Event::new(EventKind::Remove(RemoveKind::Other)).add_path(vanished2);
         assert_eq!(classify_event(root, &event2), EventAction::MarkUnknown);
         // ignored generic remove stays Noop

--- a/crates/context-index/src/watcher.rs
+++ b/crates/context-index/src/watcher.rs
@@ -4,7 +4,7 @@ use notify::{
     Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher,
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -100,10 +100,17 @@ fn normalize_rel(root: &Path, abs: &Path) -> Option<String> {
     let rel = abs.strip_prefix(root).ok()?;
     let s = rel.to_string_lossy().replace('\\', "/");
     if s.is_empty() {
-        None
-    } else {
-        Some(s)
+        return None;
     }
+    if Path::new(&s).components().any(|c| {
+        matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return None;
+    }
+    Some(s)
 }
 
 impl StructuralWatcher {
@@ -992,6 +999,27 @@ mod tests {
         let after = tracker.snapshot();
         assert_eq!(after.state, before.state);
         assert_eq!(after.epoch, before.epoch, "Noop must not bump epoch");
+    }
+
+    #[test]
+    fn classify_parent_dir_component_is_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let evil = root.join("a/../b.rs");
+        let event =
+            Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content))).add_path(evil);
+        assert_eq!(
+            classify_event(root, &event),
+            EventAction::MarkUnknown,
+            "path containing ParentDir '..' must classify as Unknown"
+        );
+        let evil2 = root.join("src/../../secret.txt");
+        let event2 = Event::new(EventKind::Create(CreateKind::File)).add_path(evil2);
+        assert_eq!(
+            classify_event(root, &event2),
+            EventAction::MarkUnknown,
+            "escape via '..' must classify as Unknown"
+        );
     }
 
     #[test]

--- a/crates/contextd/src/cli.rs
+++ b/crates/contextd/src/cli.rs
@@ -303,7 +303,7 @@ pub async fn run_cli(cli: Cli) -> Result<()> {
             }
         }
         Some(Command::Index { semantic }) => {
-            let svc = ContextService::new(root).await?;
+            let svc = ContextService::new_for_index(root)?;
             let stats = if semantic {
                 svc.full_semantic_index().await?
             } else {

--- a/crates/contextd/src/lib.rs
+++ b/crates/contextd/src/lib.rs
@@ -5,4 +5,5 @@ pub mod candidate;
 pub mod config;
 pub mod pipeline;
 pub mod project;
+pub mod runtime;
 pub mod service;

--- a/crates/contextd/src/main.rs
+++ b/crates/contextd/src/main.rs
@@ -7,6 +7,7 @@ mod config;
 mod mcp;
 mod pipeline;
 mod project;
+mod runtime;
 mod service;
 
 use clap::Parser;

--- a/crates/contextd/src/pipeline.rs
+++ b/crates/contextd/src/pipeline.rs
@@ -79,6 +79,15 @@ pub struct PipelineStats {
     pub vector_count_scanned: Option<usize>,
     #[serde(default)]
     pub cache_hit: Option<bool>,
+    // E2 persistent-runtime telemetry — nullable, filled only in service paths.
+    #[serde(default)]
+    pub reconcile_skipped: Option<bool>,
+    #[serde(default)]
+    pub discovery_calls: Option<u32>,
+    #[serde(default)]
+    pub reconcile_calls: Option<u32>,
+    #[serde(default)]
+    pub runtime_state: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1029,6 +1038,10 @@ pub async fn retrieve_context(
         dirty_file_count: None,
         vector_count_scanned,
         cache_hit: None,
+        reconcile_skipped: None,
+        discovery_calls: None,
+        reconcile_calls: None,
+        runtime_state: None,
     };
 
     Ok(ContextResult {

--- a/crates/contextd/src/runtime.rs
+++ b/crates/contextd/src/runtime.rs
@@ -1,0 +1,227 @@
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use context_index::embed::ModelFingerprint;
+use context_index::watcher::{DirtyTracker, RepositoryWatcher};
+use context_index::ProjectIndex;
+
+pub(crate) const FULL_VERIFY_INTERVAL: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeState {
+    Unknown,
+    Clean,
+    Dirty,
+}
+
+pub(crate) struct RuntimeData {
+    project: Option<Arc<ProjectIndex>>,
+    generation: u64,
+    semantic_fingerprint: ModelFingerprint,
+    last_full_verified: Option<Instant>,
+    discovery_total: u64,
+    reconcile_total: u64,
+}
+
+pub(crate) struct RepositoryRuntime {
+    #[allow(dead_code)]
+    root: PathBuf,
+    pub(crate) tracker: DirtyTracker,
+    _watcher: RepositoryWatcher,
+    data: std::sync::Mutex<RuntimeData>,
+    pub(crate) reconcile_lock: tokio::sync::Mutex<()>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeSnapshot {
+    pub project: Arc<ProjectIndex>,
+    pub generation: u64,
+    #[allow(dead_code)]
+    pub semantic_fingerprint: ModelFingerprint,
+    #[allow(dead_code)]
+    pub last_full_verified: Option<Instant>,
+}
+
+impl RepositoryRuntime {
+    pub(crate) fn new(root: PathBuf) -> Result<Self, context_core::ContextError> {
+        let watcher = RepositoryWatcher::new(root.clone())
+            .map_err(|e| context_core::ContextError::Internal(format!("watcher failed: {e}")))?;
+        let tracker = watcher.tracker().clone();
+        tracker.mark_unknown();
+        Ok(Self {
+            root,
+            tracker,
+            _watcher: watcher,
+            data: std::sync::Mutex::new(RuntimeData {
+                project: None,
+                generation: 0,
+                semantic_fingerprint: context_index::embed::configured_fingerprint(),
+                last_full_verified: None,
+                discovery_total: 0,
+                reconcile_total: 0,
+            }),
+            reconcile_lock: tokio::sync::Mutex::new(()),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn state(&self) -> RuntimeState {
+        match self.tracker.snapshot().state {
+            context_index::watcher::DirtyState::Clean => RuntimeState::Clean,
+            context_index::watcher::DirtyState::Paths(_) => RuntimeState::Dirty,
+            context_index::watcher::DirtyState::Unknown => RuntimeState::Unknown,
+        }
+    }
+
+    pub(crate) fn current_snapshot(&self) -> Option<RuntimeSnapshot> {
+        let guard = self.data.lock().ok()?;
+        let project = guard.project.clone()?;
+        Some(RuntimeSnapshot {
+            project,
+            generation: guard.generation,
+            semantic_fingerprint: guard.semantic_fingerprint.clone(),
+            last_full_verified: guard.last_full_verified,
+        })
+    }
+
+    pub(crate) fn is_verification_expired(&self, now: Instant) -> bool {
+        let guard = match self.data.lock() {
+            Ok(g) => g,
+            Err(_) => return true,
+        };
+        match guard.last_full_verified {
+            Some(t) => now
+                .checked_duration_since(t)
+                .map(|elapsed| elapsed >= FULL_VERIFY_INTERVAL)
+                .unwrap_or(false),
+            None => true,
+        }
+    }
+
+    /// Publish a validated project snapshot. Must be called while holding
+    /// `reconcile_lock` (or during single-threaded initialization) so that
+    /// the counters stay consistent with the work that produced the snapshot.
+    pub(crate) fn publish(
+        &self,
+        project: Arc<ProjectIndex>,
+        generation: u64,
+        fingerprint: ModelFingerprint,
+        now: Instant,
+    ) {
+        let mut guard = self.data.lock().expect("runtime data mutex poisoned");
+        guard.project = Some(project);
+        guard.generation = generation;
+        guard.semantic_fingerprint = fingerprint;
+        guard.last_full_verified = Some(now);
+        guard.reconcile_total = guard.reconcile_total.saturating_add(1);
+    }
+
+    pub(crate) fn increment_discovery(&self) {
+        let mut guard = self.data.lock().expect("runtime data mutex poisoned");
+        guard.discovery_total = guard.discovery_total.saturating_add(1);
+    }
+
+    #[cfg(test)]
+    pub fn counters(&self) -> (u64, u64) {
+        let guard = self.data.lock().expect("runtime data mutex poisoned");
+        (guard.discovery_total, guard.reconcile_total)
+    }
+
+    #[cfg(test)]
+    pub fn set_last_full_verified(&self, instant: Instant) {
+        let mut guard = self.data.lock().expect("runtime data mutex poisoned");
+        guard.last_full_verified = Some(instant);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use context_index::watcher::DirtyState;
+    use std::time::Instant;
+    use tempfile::TempDir;
+
+    #[test]
+    fn initial_state_is_unknown() {
+        let tmp = TempDir::new().unwrap();
+        let rt = RepositoryRuntime::new(tmp.path().to_path_buf()).unwrap();
+        assert_eq!(rt.state(), RuntimeState::Unknown);
+        assert!(rt.current_snapshot().is_none());
+        assert_eq!(rt.counters(), (0, 0));
+    }
+
+    #[test]
+    fn publish_and_ack_cleans_state() {
+        let tmp = TempDir::new().unwrap();
+        let rt = RepositoryRuntime::new(tmp.path().to_path_buf()).unwrap();
+        let epoch = rt.tracker.snapshot().epoch;
+        let root = context_index::ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        let idx = context_index::ProjectIndex::discover(&root).unwrap();
+        rt.publish(
+            Arc::new(idx),
+            1,
+            ModelFingerprint {
+                model_id: "m".into(),
+                version: "v".into(),
+                dimension: 1,
+            },
+            Instant::now(),
+        );
+        rt.tracker.acknowledge(epoch);
+        assert_eq!(rt.state(), RuntimeState::Clean);
+        assert_eq!(rt.counters(), (0, 1));
+        assert!(rt.current_snapshot().is_some());
+    }
+
+    #[test]
+    fn epoch_mismatch_retains_dirty() {
+        let tmp = TempDir::new().unwrap();
+        let rt = RepositoryRuntime::new(tmp.path().to_path_buf()).unwrap();
+        let initial_epoch = rt.tracker.snapshot().epoch;
+        let root = context_index::ProjectRoot::resolve(Some(tmp.path())).unwrap();
+        let idx = context_index::ProjectIndex::discover(&root).unwrap();
+        rt.publish(
+            Arc::new(idx),
+            1,
+            ModelFingerprint {
+                model_id: "m".into(),
+                version: "v".into(),
+                dimension: 1,
+            },
+            Instant::now(),
+        );
+        rt.tracker.acknowledge(initial_epoch);
+        rt.tracker.mark_paths(["a.py".to_string()]);
+        let snapshot = rt.tracker.snapshot();
+        rt.tracker.mark_paths(["b.py".to_string()]);
+        rt.tracker.acknowledge(snapshot.epoch);
+        assert_eq!(rt.state(), RuntimeState::Dirty);
+        assert!(matches!(rt.tracker.snapshot().state, DirtyState::Paths(_)));
+    }
+
+    #[test]
+    fn root_identity() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let rt = RepositoryRuntime::new(root.clone()).unwrap();
+        assert_eq!(rt.root(), root);
+    }
+
+    #[test]
+    fn verification_expiry() {
+        let tmp = TempDir::new().unwrap();
+        let rt = RepositoryRuntime::new(tmp.path().to_path_buf()).unwrap();
+        let now = Instant::now();
+        rt.set_last_full_verified(now - FULL_VERIFY_INTERVAL - Duration::from_secs(1));
+        assert!(rt.is_verification_expired(now));
+        rt.set_last_full_verified(now);
+        assert!(!rt.is_verification_expired(now));
+    }
+}

--- a/crates/contextd/src/runtime.rs
+++ b/crates/contextd/src/runtime.rs
@@ -33,6 +33,8 @@ pub(crate) struct RepositoryRuntime {
     _watcher: RepositoryWatcher,
     data: std::sync::Mutex<RuntimeData>,
     pub(crate) reconcile_lock: tokio::sync::Mutex<()>,
+    #[cfg(test)]
+    test_hook: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -64,6 +66,8 @@ impl RepositoryRuntime {
                 reconcile_total: 0,
             }),
             reconcile_lock: tokio::sync::Mutex::new(()),
+            #[cfg(test)]
+            test_hook: std::sync::Mutex::new(None),
         })
     }
 
@@ -77,6 +81,13 @@ impl RepositoryRuntime {
             context_index::watcher::DirtyState::Clean => RuntimeState::Clean,
             context_index::watcher::DirtyState::Paths(_) => RuntimeState::Dirty,
             context_index::watcher::DirtyState::Unknown => RuntimeState::Unknown,
+        }
+    }
+
+    pub(crate) fn dirty_paths(&self) -> Option<std::collections::BTreeSet<String>> {
+        match self.tracker.snapshot().state {
+            context_index::watcher::DirtyState::Paths(paths) => Some(paths),
+            _ => None,
         }
     }
 
@@ -138,6 +149,24 @@ impl RepositoryRuntime {
     pub fn set_last_full_verified(&self, instant: Instant) {
         let mut guard = self.data.lock().expect("runtime data mutex poisoned");
         guard.last_full_verified = Some(instant);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_test_hook(&self, hook: Box<dyn Fn() + Send + Sync>) {
+        if let Ok(mut guard) = self.test_hook.lock() {
+            *guard = Some(hook);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn run_test_hook(&self) {
+        let hook = match self.test_hook.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(_) => None,
+        };
+        if let Some(hook) = hook {
+            hook();
+        }
     }
 }
 

--- a/crates/contextd/src/runtime.rs
+++ b/crates/contextd/src/runtime.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 #[cfg(test)]
 use std::path::Path;
 use std::path::PathBuf;
@@ -35,6 +36,8 @@ pub(crate) struct RepositoryRuntime {
     pub(crate) reconcile_lock: tokio::sync::Mutex<()>,
     #[cfg(test)]
     test_hook: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
+    #[cfg(test)]
+    pre_reconcile_hook: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -42,9 +45,16 @@ pub(crate) struct RuntimeSnapshot {
     pub project: Arc<ProjectIndex>,
     pub generation: u64,
     #[allow(dead_code)]
-    pub semantic_fingerprint: ModelFingerprint,
-    #[allow(dead_code)]
     pub last_full_verified: Option<Instant>,
+}
+
+/// Single atomic view of dirty state, captured paths, and epoch. Derived from one
+/// `DirtyTracker::snapshot()` so `state`, `paths`, and `epoch` can never disagree.
+#[derive(Debug, Clone)]
+pub(crate) struct DirtyAccess {
+    pub state: RuntimeState,
+    pub paths: Option<BTreeSet<String>>,
+    pub epoch: u64,
 }
 
 impl RepositoryRuntime {
@@ -68,6 +78,8 @@ impl RepositoryRuntime {
             reconcile_lock: tokio::sync::Mutex::new(()),
             #[cfg(test)]
             test_hook: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            pre_reconcile_hook: std::sync::Mutex::new(None),
         })
     }
 
@@ -76,6 +88,7 @@ impl RepositoryRuntime {
         &self.root
     }
 
+    #[cfg(test)]
     pub(crate) fn state(&self) -> RuntimeState {
         match self.tracker.snapshot().state {
             context_index::watcher::DirtyState::Clean => RuntimeState::Clean,
@@ -84,11 +97,28 @@ impl RepositoryRuntime {
         }
     }
 
-    pub(crate) fn dirty_paths(&self) -> Option<std::collections::BTreeSet<String>> {
-        match self.tracker.snapshot().state {
-            context_index::watcher::DirtyState::Paths(paths) => Some(paths),
-            _ => None,
+    /// Capture dirty state, paths, and epoch in a single tracker snapshot so a
+    /// concurrent watcher event cannot split them (the source of the F1/F2 race).
+    pub(crate) fn dirty_access(&self) -> DirtyAccess {
+        let snap = self.tracker.snapshot();
+        let (state, paths) = match snap.state {
+            context_index::watcher::DirtyState::Clean => (RuntimeState::Clean, None),
+            context_index::watcher::DirtyState::Paths(paths) => (RuntimeState::Dirty, Some(paths)),
+            context_index::watcher::DirtyState::Unknown => (RuntimeState::Unknown, None),
+        };
+        DirtyAccess {
+            state,
+            paths,
+            epoch: snap.epoch,
         }
+    }
+
+    pub(crate) fn semantic_fingerprint(&self) -> ModelFingerprint {
+        let guard = match self.data.lock() {
+            Ok(g) => g,
+            Err(_) => return context_index::embed::configured_fingerprint(),
+        };
+        guard.semantic_fingerprint.clone()
     }
 
     pub(crate) fn current_snapshot(&self) -> Option<RuntimeSnapshot> {
@@ -97,7 +127,6 @@ impl RepositoryRuntime {
         Some(RuntimeSnapshot {
             project,
             generation: guard.generation,
-            semantic_fingerprint: guard.semantic_fingerprint.clone(),
             last_full_verified: guard.last_full_verified,
         })
     }
@@ -119,18 +148,27 @@ impl RepositoryRuntime {
     /// Publish a validated project snapshot. Must be called while holding
     /// `reconcile_lock` (or during single-threaded initialization) so that
     /// the counters stay consistent with the work that produced the snapshot.
+    ///
+    /// `full_verification` is true only when the snapshot verified the whole
+    /// repository (initial/full discovery). Incremental dirty-path publishes
+    /// must preserve the existing `last_full_verified` deadline, otherwise a
+    /// stream of single-file edits would postpone periodic full verification
+    /// indefinitely.
     pub(crate) fn publish(
         &self,
         project: Arc<ProjectIndex>,
         generation: u64,
         fingerprint: ModelFingerprint,
         now: Instant,
+        full_verification: bool,
     ) {
         let mut guard = self.data.lock().expect("runtime data mutex poisoned");
         guard.project = Some(project);
         guard.generation = generation;
         guard.semantic_fingerprint = fingerprint;
-        guard.last_full_verified = Some(now);
+        if full_verification {
+            guard.last_full_verified = Some(now);
+        }
         guard.reconcile_total = guard.reconcile_total.saturating_add(1);
     }
 
@@ -161,6 +199,27 @@ impl RepositoryRuntime {
     #[cfg(test)]
     pub(crate) fn run_test_hook(&self) {
         let hook = match self.test_hook.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(_) => None,
+        };
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    /// Test hook fired between the dirty-path snapshot capture and the start of
+    /// the path-local reconcile. Lets a test inject a watcher event in the exact
+    /// F1 window (after `dirty_access()` captures paths+epoch, before reconcile).
+    #[cfg(test)]
+    pub(crate) fn set_pre_reconcile_hook(&self, hook: Box<dyn Fn() + Send + Sync>) {
+        if let Ok(mut guard) = self.pre_reconcile_hook.lock() {
+            *guard = Some(hook);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn run_pre_reconcile_hook(&self) {
+        let hook = match self.pre_reconcile_hook.lock() {
             Ok(mut guard) => guard.take(),
             Err(_) => None,
         };
@@ -202,6 +261,7 @@ mod tests {
                 dimension: 1,
             },
             Instant::now(),
+            true,
         );
         rt.tracker.acknowledge(epoch);
         assert_eq!(rt.state(), RuntimeState::Clean);
@@ -225,6 +285,7 @@ mod tests {
                 dimension: 1,
             },
             Instant::now(),
+            true,
         );
         rt.tracker.acknowledge(initial_epoch);
         rt.tracker.mark_paths(["a.py".to_string()]);

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -133,10 +133,7 @@ pub struct ContextService {
 }
 
 impl ContextService {
-    /// Create service for given root (or auto-resolve via ProjectRoot::resolve).
-    /// Starts the mark-only watcher and completes one full discovery/reconcile
-    /// before returning so that the runtime snapshot is immediately usable.
-    pub async fn new(root: Option<PathBuf>) -> Result<Self, ContextError> {
+    fn build(root: Option<PathBuf>) -> Result<Self, ContextError> {
         let root_path = if let Some(p) = root.clone() {
             p.canonicalize().unwrap_or(p)
         } else {
@@ -147,13 +144,24 @@ impl ContextService {
         let runtime = Arc::new(RepositoryRuntime::new(root_path.clone()).map_err(|e| {
             ContextError::Internal(format!("failed to start repository runtime: {e}"))
         })?);
-        let service = Self {
+        Ok(Self {
             root: root_path,
             explicit_root: root,
             runtime,
-        };
+        })
+    }
+
+    /// Create service for given root (or auto-resolve via ProjectRoot::resolve).
+    /// Starts the mark-only watcher and completes one full discovery/reconcile
+    /// before returning so that the runtime snapshot is immediately usable.
+    pub async fn new(root: Option<PathBuf>) -> Result<Self, ContextError> {
+        let service = Self::build(root)?;
         service.initialize().await?;
         Ok(service)
+    }
+
+    pub(crate) fn new_for_index(root: Option<PathBuf>) -> Result<Self, ContextError> {
+        Self::build(root)
     }
 
     async fn initialize(&self) -> Result<(), ContextError> {
@@ -262,6 +270,10 @@ impl ContextService {
         if !outcome.deleted_files.is_empty() {
             if let Ok(conn) = structural_store::open_db(root.path()) {
                 let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
+                let prev = self.runtime.semantic_fingerprint();
+                if prev != fingerprint {
+                    let _ = context_index::vector::gc_orphaned_vectors(&conn, &prev);
+                }
             }
         }
 
@@ -2232,6 +2244,59 @@ mod tests {
         assert!(
             !svc.runtime.is_verification_expired(Instant::now()),
             "full discovery must clear the expired deadline"
+        );
+    }
+
+    #[tokio::test]
+    async fn index_constructor_starts_uninitialized() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new_for_index(Some(root.clone())).unwrap();
+        assert_eq!(
+            svc.runtime.counters(),
+            (0, 0),
+            "index constructor must not perform discovery/reconcile"
+        );
+    }
+
+    #[tokio::test]
+    async fn index_nonsemantic_reconcile_single_pass() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new_for_index(Some(root.clone())).unwrap();
+        assert_eq!(svc.runtime.counters(), (0, 0));
+        let stats = svc.reconcile().await.unwrap();
+        assert!(stats.discovered > 0);
+        assert_eq!(
+            svc.runtime.counters(),
+            (1, 1),
+            "nonsemantic index must perform exactly one discovery and one reconcile"
+        );
+    }
+
+    #[tokio::test]
+    async fn index_semantic_single_pass_with_fake_embedder() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        fs::write(root.join("b.py"), b"def bar():\n    pass\n").unwrap();
+        let svc = ContextService::new_for_index(Some(root.clone())).unwrap();
+        assert_eq!(svc.runtime.counters(), (0, 0));
+        let fake = std::sync::Arc::new(context_index::embed::FakeEmbedder::new("idx-sem-test", 8));
+        let stats = svc
+            .full_semantic_index_with_embedder(fake.clone())
+            .await
+            .unwrap();
+        assert!(stats.vectors_created > 0);
+        assert_eq!(
+            svc.runtime.counters(),
+            (1, 1),
+            "semantic index with FakeEmbedder must perform exactly one discovery and one reconcile"
         );
     }
 }

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -6,6 +7,7 @@ use std::time::Instant;
 use context_core::ContextError;
 use context_index::embed::Embedder;
 use context_index::structural::store as structural_store;
+use context_index::structural::{detect_language, Language};
 use context_index::{ProjectIndex, ProjectRoot};
 
 use crate::pipeline::{retrieve_context, ContextResult, Providers};
@@ -66,6 +68,19 @@ pub struct ReconcileStats {
     pub vectors_created: usize,
     pub vectors_reused: usize,
     pub embedding_calls: usize,
+}
+
+/// Snapshot access result for search/dependency, carrying truthful E2 telemetry.
+pub(crate) struct RuntimeAccess {
+    pub project: Arc<ProjectIndex>,
+    pub generation: u64,
+    pub reconcile_skipped: bool,
+    pub discovery_calls: u32,
+    pub reconcile_calls: u32,
+    pub runtime_state: &'static str,
+    pub dirty_file_count: usize,
+    pub discovery_ms: u128,
+    pub reconcile_ms: u128,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -249,6 +264,8 @@ impl ContextService {
         let project_arc = Arc::new(idx);
         self.runtime
             .publish(project_arc.clone(), generation, fingerprint, Instant::now());
+        #[cfg(test)]
+        self.runtime.run_test_hook();
         self.runtime.tracker.acknowledge(epoch);
         Ok((stats, project_arc, discovery_ms))
     }
@@ -311,36 +328,242 @@ impl ContextService {
         Ok(stats)
     }
 
-    async fn access_project(
+    /// Shared runtime access for search and dependency. Caller acquires the
+    /// reconcile lock and releases it before retrieval runs.
+    async fn access_runtime(
         &self,
         override_embedder: Option<Arc<dyn Embedder>>,
-    ) -> Result<(Arc<ProjectIndex>, u128, ReconcileStats), ContextError> {
+    ) -> Result<RuntimeAccess, ContextError> {
         let _guard = self.runtime.reconcile_lock.lock().await;
-        let snapshot = self.runtime.current_snapshot();
-        if self.runtime.state() == RuntimeState::Clean
-            && !self.runtime.is_verification_expired(Instant::now())
-        {
-            let snapshot = snapshot.ok_or_else(|| {
+        let now = Instant::now();
+        let state = self.runtime.state();
+        let dirty = self.runtime.dirty_paths();
+        let has_snapshot = self.runtime.current_snapshot().is_some();
+
+        if state == RuntimeState::Clean && !self.runtime.is_verification_expired(now) {
+            let snapshot = self.runtime.current_snapshot().ok_or_else(|| {
                 ContextError::Internal("clean runtime has no project snapshot".into())
             })?;
-            return Ok((
-                snapshot.project,
-                0,
-                ReconcileStats {
-                    discovered: 0,
-                    changed_files: 0,
-                    deleted_files: 0,
-                    elapsed_ms: 0,
-                    vectors_created: 0,
-                    vectors_reused: 0,
-                    embedding_calls: 0,
-                },
-            ));
+            return Ok(RuntimeAccess {
+                project: snapshot.project,
+                generation: snapshot.generation,
+                reconcile_skipped: true,
+                discovery_calls: 0,
+                reconcile_calls: 0,
+                runtime_state: "clean",
+                dirty_file_count: 0,
+                discovery_ms: 0,
+                reconcile_ms: 0,
+            });
         }
 
+        if let Some(paths) = dirty {
+            if has_snapshot {
+                let dirty_count = paths.len();
+                let (stats, project) = self
+                    .reconcile_dirty_paths_locked(override_embedder, &paths)
+                    .await?;
+                let generation = self
+                    .runtime
+                    .current_snapshot()
+                    .map(|s| s.generation)
+                    .unwrap_or(0);
+                return Ok(RuntimeAccess {
+                    project,
+                    generation,
+                    reconcile_skipped: false,
+                    discovery_calls: 0,
+                    reconcile_calls: 1,
+                    runtime_state: "dirty",
+                    dirty_file_count: dirty_count,
+                    discovery_ms: 0,
+                    reconcile_ms: stats.elapsed_ms,
+                });
+            }
+        }
+
+        // Unknown, expired, or dirty-without-snapshot: one full discovery/reconcile.
         let (stats, project, discovery_ms) =
             self.reconcile_and_publish_locked(override_embedder).await?;
-        Ok((project, discovery_ms, stats))
+        let generation = self
+            .runtime
+            .current_snapshot()
+            .map(|s| s.generation)
+            .unwrap_or(0);
+        Ok(RuntimeAccess {
+            project,
+            generation,
+            reconcile_skipped: false,
+            discovery_calls: 1,
+            reconcile_calls: 1,
+            runtime_state: "unknown",
+            dirty_file_count: 0,
+            discovery_ms,
+            reconcile_ms: stats.elapsed_ms,
+        })
+    }
+
+    /// Path-local dirty reconciliation. Caller holds `reconcile_lock`.
+    /// Only `refresh_paths` re-scans captured paths; structural updates run
+    /// through `update_single_file` inside `spawn_blocking`.
+    async fn reconcile_dirty_paths_locked(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+        paths: &BTreeSet<String>,
+    ) -> Result<(ReconcileStats, Arc<ProjectIndex>), ContextError> {
+        let epoch = self.runtime.tracker.snapshot().epoch;
+        let t0 = Instant::now();
+        let root = ProjectRoot::resolve(Some(&self.root))
+            .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
+
+        let fingerprint = override_embedder
+            .as_ref()
+            .map(|e| e.fingerprint())
+            .unwrap_or_else(context_index::embed::configured_fingerprint);
+        // Structural mutation may change semantic refs; sample readiness first.
+        let was_semantic_ready = structural_store::open_db(root.path())
+            .ok()
+            .and_then(|conn| {
+                context_index::vector::is_semantic_ready(&conn, &fingerprint, true).ok()
+            })
+            .unwrap_or(false);
+
+        let current = self
+            .runtime
+            .current_snapshot()
+            .ok_or_else(|| ContextError::Internal("no project snapshot to refresh".into()))?
+            .project;
+
+        // Path-local snapshot refresh — never a full walk.
+        let delta = current
+            .refresh_paths(paths)
+            .map_err(|e| ContextError::Internal(e.to_string()))?;
+
+        let root_path = root.path().to_path_buf();
+        let changed = delta.changed_files.clone();
+        let deleted = delta.deleted_files.clone();
+        let (parsed, removed) = tokio::task::spawn_blocking(move || {
+            let si = context_index::structural::StructuralIndex::for_path(root_path);
+            let mut parsed = Vec::new();
+            let mut removed = Vec::new();
+            for f in &changed {
+                if detect_language(std::path::Path::new(f)) == Language::Unknown {
+                    continue;
+                }
+                let stats = si
+                    .update_single_file(f)
+                    .map_err(|e| ContextError::Internal(e.to_string()))?;
+                if stats.files_parsed == 1 {
+                    parsed.push(f.clone());
+                }
+            }
+            for f in &deleted {
+                if detect_language(std::path::Path::new(f)) == Language::Unknown {
+                    continue;
+                }
+                let stats = si
+                    .update_single_file(f)
+                    .map_err(|e| ContextError::Internal(e.to_string()))?;
+                if stats.files_deleted == 1 {
+                    removed.push(f.clone());
+                }
+            }
+            Ok::<_, ContextError>((parsed, removed))
+        })
+        .await
+        .map_err(|e| ContextError::Internal(format!("structural update panicked: {e}")))??;
+
+        let backend_available = if override_embedder.is_some() {
+            true
+        } else {
+            context_index::embed::is_configured_model_available().await
+        };
+
+        let mut vectors_created = 0usize;
+        let mut vectors_reused = 0usize;
+        let mut embedding_calls = 0usize;
+
+        if backend_available {
+            let embedder: Arc<dyn Embedder> = override_embedder
+                .clone()
+                .unwrap_or_else(|| Arc::new(context_index::embed::configured_embedder()));
+            match structural_store::open_db(root.path()) {
+                Ok(mut conn) => {
+                    if was_semantic_ready && !parsed.is_empty() {
+                        match context_index::vector::sync_changed_files_vectors(
+                            &mut conn,
+                            root.path(),
+                            &parsed,
+                            embedder.as_ref(),
+                        )
+                        .await
+                        {
+                            Ok((reused, embedded, calls)) => {
+                                vectors_reused = reused;
+                                vectors_created = embedded;
+                                embedding_calls = calls;
+                            }
+                            Err(e) => tracing::warn!(error=%e, "incremental semantic sync failed"),
+                        }
+                    }
+                    if !removed.is_empty() {
+                        let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
+                    }
+                }
+                Err(e) => tracing::warn!(error=%e, "open_db for semantic sync failed"),
+            }
+        }
+
+        // Truthful repository generation: bump once when the project snapshot
+        // content changed but no structural file was actually parsed/deleted.
+        let structural_changed = !parsed.is_empty() || !removed.is_empty();
+        let content_changed = {
+            let mut any = !delta.deleted_files.is_empty();
+            if !any {
+                for f in &delta.changed_files {
+                    let old_hash = current.find_by_path(f).map(|r| r.content_hash.clone());
+                    let new_hash = delta
+                        .project
+                        .find_by_path(f)
+                        .map(|r| r.content_hash.clone());
+                    if old_hash != new_hash {
+                        any = true;
+                        break;
+                    }
+                }
+            }
+            any
+        };
+        let mut generation = structural_store::open_db(root.path())
+            .ok()
+            .and_then(|c| structural_store::get_generation(&c).ok())
+            .unwrap_or(0);
+        if content_changed && !structural_changed {
+            if let Ok(conn) = structural_store::open_db(root.path()) {
+                let next = generation.saturating_add(1);
+                if structural_store::set_generation(&conn, next).is_ok() {
+                    generation = next;
+                }
+            }
+        }
+
+        let elapsed = t0.elapsed().as_millis();
+        let stats = ReconcileStats {
+            discovered: delta.project.stats.discovered,
+            changed_files: parsed.len(),
+            deleted_files: removed.len(),
+            elapsed_ms: elapsed,
+            vectors_created,
+            vectors_reused,
+            embedding_calls,
+        };
+        let project_arc = Arc::new(delta.project);
+        self.runtime
+            .publish(project_arc.clone(), generation, fingerprint, Instant::now());
+        #[cfg(test)]
+        self.runtime.run_test_hook();
+        self.runtime.tracker.acknowledge(epoch);
+        Ok((stats, project_arc))
     }
 
     /// Cheap reconcile — discovery + incremental structural/BM25 + semantic if available (fast, incremental only).
@@ -374,15 +597,24 @@ impl ContextService {
         query: &str,
         opts: SearchOptions,
     ) -> Result<ContextResult, ContextError> {
+        self.search_with_override(query, opts, None).await
+    }
+
+    async fn search_with_override(
+        &self,
+        query: &str,
+        opts: SearchOptions,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<ContextResult, ContextError> {
         let t_search = std::time::Instant::now();
-        let (project, discovery_ms, reconcile_stats) = self
-            .access_project(None)
+        let access = self
+            .access_runtime(override_embedder)
             .await
             .map_err(|e| ContextError::Internal(format!("reconcile failed: {e}")))?;
         let providers = Providers {};
         let mut res = retrieve_context(
             query,
-            &project,
+            &access.project,
             &providers,
             opts.budget_tokens,
             opts.max_results,
@@ -391,21 +623,30 @@ impl ContextService {
         .map_err(|e| ContextError::Internal(e.to_string()))?;
         // Fill stage telemetry at service layer
         let total_ms = t_search.elapsed().as_millis();
-        let generation = self
-            .runtime
-            .current_snapshot()
-            .map(|snapshot| snapshot.generation);
         res.stats.total_ms = Some(total_ms);
-        res.stats.discovery_ms = Some(discovery_ms);
-        res.stats.reconcile_ms = Some(reconcile_stats.elapsed_ms);
-        res.stats.generation = generation;
-        // dirty_file_count stays None until E2 (no dirty tracking yet)
-        res.stats.dirty_file_count = None;
+        res.stats.discovery_ms = Some(access.discovery_ms);
+        res.stats.reconcile_ms = Some(access.reconcile_ms);
+        res.stats.generation = Some(access.generation);
+        res.stats.dirty_file_count = Some(access.dirty_file_count);
+        res.stats.reconcile_skipped = Some(access.reconcile_skipped);
+        res.stats.discovery_calls = Some(access.discovery_calls);
+        res.stats.reconcile_calls = Some(access.reconcile_calls);
+        res.stats.runtime_state = Some(access.runtime_state.to_string());
         res.stats.cache_hit = None;
         if res.stats.authority_ms.is_none() {
             res.stats.authority_ms = Some(res.stats.rank_ms);
         }
         Ok(res)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn search_with_embedder(
+        &self,
+        query: &str,
+        opts: SearchOptions,
+        embedder: Arc<dyn Embedder>,
+    ) -> Result<ContextResult, ContextError> {
+        self.search_with_override(query, opts, Some(embedder)).await
     }
 
     pub async fn symbol(
@@ -423,8 +664,8 @@ impl ContextService {
         opts: SearchOptions,
     ) -> Result<ContextResult, ContextError> {
         // Graph-native dependency retrieval: directly query call graph, not via generic search
-        // E1: reconcile already does one discovery; remove duplicate unused ProjectIndex::discover
-        self.reconcile_fast_inner(None)
+        let access = self
+            .access_runtime(None)
             .await
             .map_err(|e| ContextError::Internal(format!("reconcile failed: {e}")))?;
         let root = ProjectRoot::resolve(Some(&self.root))
@@ -682,16 +923,20 @@ impl ContextService {
             rank_ms,
             pack_ms,
             total_ms: Some(elapsed_ms),
-            discovery_ms: None,
-            reconcile_ms: None,
+            discovery_ms: Some(access.discovery_ms),
+            reconcile_ms: Some(access.reconcile_ms),
             semantic_embed_ms: None,
             semantic_search_ms: None,
             fusion_ms: Some(fuse_ms),
             authority_ms: Some(rank_ms),
-            generation: None,
-            dirty_file_count: None,
+            generation: Some(access.generation),
+            dirty_file_count: Some(access.dirty_file_count),
             vector_count_scanned: None,
             cache_hit: None,
+            reconcile_skipped: Some(access.reconcile_skipped),
+            discovery_calls: Some(access.discovery_calls),
+            reconcile_calls: Some(access.reconcile_calls),
+            runtime_state: Some(access.runtime_state.to_string()),
         };
         Ok(crate::pipeline::ContextResult {
             query: symbol.to_string(),
@@ -1398,5 +1643,339 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn clean_searches_keep_counters_unchanged() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let (d0, r0) = svc.runtime.counters();
+        let mut first_gen = None;
+        for _ in 0..5 {
+            let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+            assert_eq!(res.stats.discovery_calls, Some(0));
+            assert_eq!(res.stats.reconcile_calls, Some(0));
+            assert_eq!(res.stats.reconcile_skipped, Some(true));
+            assert_eq!(res.stats.runtime_state.as_deref(), Some("clean"));
+            assert_eq!(res.stats.dirty_file_count, Some(0));
+            first_gen = Some(res.stats.generation.unwrap());
+        }
+        let (d1, r1) = svc.runtime.counters();
+        assert_eq!(
+            (d1, r1),
+            (d0, r0),
+            "repeated clean searches must not increment totals"
+        );
+
+        let opts = SearchOptions::default();
+        let (ra, rb) = tokio::join!(svc.search("foo", opts.clone()), svc.search("foo", opts));
+        let a = ra.unwrap();
+        let b = rb.unwrap();
+        assert_eq!(a.stats.generation, b.stats.generation);
+        assert_eq!(a.stats.generation, Some(first_gen.unwrap()));
+        let (d2, r2) = svc.runtime.counters();
+        assert_eq!(
+            (d2, r2),
+            (d0, r0),
+            "concurrent clean searches must not increment totals"
+        );
+    }
+
+    #[tokio::test]
+    async fn dirty_modify_reconciles_path_local_once() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        fs::write(root.join("b.py"), b"def bar():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let gen0 = svc.runtime.current_snapshot().unwrap().generation;
+        let (d0, r0) = svc.runtime.counters();
+
+        fs::write(root.join("a.py"), b"def foo():\n    return 42\n").unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res.stats.discovery_calls, Some(0));
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+        assert_eq!(res.stats.reconcile_skipped, Some(false));
+        assert_eq!(res.stats.runtime_state.as_deref(), Some("dirty"));
+        assert_eq!(res.stats.dirty_file_count, Some(1));
+        let gen1 = res.stats.generation.unwrap();
+        assert_eq!(gen1, gen0 + 1, "one-file mutation advances generation once");
+        let (d1, r1) = svc.runtime.counters();
+        assert_eq!(d1, d0, "dirty path must not run discovery");
+        assert_eq!(r1, r0 + 1);
+
+        // A second search (possibly processing a duplicate watcher event for the
+        // same path) must not advance generation further.
+        let res2 = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res2.stats.generation, Some(gen1));
+    }
+
+    #[tokio::test]
+    async fn dirty_no_content_change_does_not_advance_generation() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let gen0 = svc.runtime.current_snapshot().unwrap().generation;
+
+        // Rewrite identical content (touch) and mark dirty.
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+        assert_eq!(res.stats.runtime_state.as_deref(), Some("dirty"));
+        assert_eq!(
+            res.stats.generation,
+            Some(gen0),
+            "no-content-change event must not advance generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn dirty_create_is_visible() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let gen0 = svc.runtime.current_snapshot().unwrap().generation;
+
+        fs::write(root.join("c.py"), b"def baz():\n    pass\n").unwrap();
+        svc.runtime.tracker.mark_paths(["c.py".to_string()]);
+
+        let res = svc.search("baz", SearchOptions::default()).await.unwrap();
+        assert!(
+            res.evidence.iter().any(|e| e.file == "c.py"),
+            "created file should be visible"
+        );
+        assert_eq!(res.stats.discovery_calls, Some(0));
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+        assert_eq!(res.stats.generation, Some(gen0 + 1));
+    }
+
+    #[tokio::test]
+    async fn dirty_delete_cleans_symbols_bm25_graph() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    bar()\n").unwrap();
+        fs::write(root.join("b.py"), b"def bar():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+
+        let conn = structural_store::open_db(&root).unwrap();
+        assert!(structural_store::find_callers(&conn, "bar")
+            .unwrap()
+            .iter()
+            .any(|e| e.file == "a.py"));
+        let bm25_before = context_index::bm25::count_bm25_docs(&conn).unwrap();
+
+        fs::remove_file(root.join("a.py")).unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+
+        let conn2 = structural_store::open_db(&root).unwrap();
+        assert!(structural_store::find_definitions(&conn2, "foo")
+            .unwrap()
+            .is_empty());
+        assert!(!structural_store::find_callers(&conn2, "bar")
+            .unwrap()
+            .iter()
+            .any(|e| e.file == "a.py"));
+        assert!(!structural_store::list_files(&conn2)
+            .unwrap()
+            .iter()
+            .any(|(f, _)| f == "a.py"));
+        let bm25_after = context_index::bm25::count_bm25_docs(&conn2).unwrap();
+        assert!(
+            bm25_after < bm25_before,
+            "BM25 rows for deleted file should disappear"
+        );
+    }
+
+    #[tokio::test]
+    async fn dirty_semantic_ready_modify_embeds_only_changed() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    return 1\n").unwrap();
+        fs::write(root.join("b.py"), b"def bar():\n    return 2\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+
+        let fake_full = Arc::new(context_index::embed::FakeEmbedder::new("sem-ready", 8));
+        svc.full_semantic_index_with_embedder(fake_full.clone())
+            .await
+            .unwrap();
+        let fp = fake_full.fingerprint();
+        let conn = structural_store::open_db(&root).unwrap();
+        assert!(context_index::vector::is_semantic_ready(&conn, &fp, true).unwrap());
+        let vectors_before = context_index::vector::count_vectors(&conn, &fp).unwrap();
+
+        struct CountingEmbedder {
+            inner: context_index::embed::FakeEmbedder,
+            calls: Arc<AtomicUsize>,
+        }
+        #[async_trait::async_trait]
+        impl context_index::embed::Embedder for CountingEmbedder {
+            fn model_id(&self) -> &str {
+                self.inner.model_id()
+            }
+            fn dimension(&self) -> usize {
+                self.inner.dimension()
+            }
+            fn version(&self) -> &str {
+                self.inner.version()
+            }
+            async fn embed_query(&self, q: &str) -> anyhow::Result<Vec<f32>> {
+                self.inner.embed_query(q).await
+            }
+            async fn embed_documents(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.inner.embed_documents(texts).await
+            }
+        }
+
+        fs::write(root.join("a.py"), b"def foo():\n    return 999\n").unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counting = Arc::new(CountingEmbedder {
+            inner: context_index::embed::FakeEmbedder::new("sem-ready", 8),
+            calls: calls.clone(),
+        });
+        let res = svc
+            .search_with_embedder("foo", SearchOptions::default(), counting)
+            .await
+            .unwrap();
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "only the changed file's representations should embed"
+        );
+
+        let conn2 = structural_store::open_db(&root).unwrap();
+        assert!(context_index::vector::is_semantic_ready(&conn2, &fp, true).unwrap());
+        assert_eq!(
+            context_index::vector::missing_vector_count(&conn2, &fp).unwrap(),
+            0
+        );
+        let vectors_after = context_index::vector::count_vectors(&conn2, &fp).unwrap();
+        assert!(
+            vectors_after >= vectors_before,
+            "unrelated vectors must remain"
+        );
+
+        // Delete a.py: semantic refs disappear, remaining files stay ready.
+        fs::remove_file(root.join("a.py")).unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+        let _ = svc.search("foo", SearchOptions::default()).await.unwrap();
+        let conn3 = structural_store::open_db(&root).unwrap();
+        assert!(context_index::vector::is_semantic_ready(&conn3, &fp, true).unwrap());
+    }
+
+    #[tokio::test]
+    async fn unknown_fallback_full_reconcile() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let (d0, r0) = svc.runtime.counters();
+
+        svc.runtime.tracker.mark_unknown();
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res.stats.discovery_calls, Some(1));
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+        assert_eq!(res.stats.runtime_state.as_deref(), Some("unknown"));
+        let (d1, r1) = svc.runtime.counters();
+        assert_eq!(d1, d0 + 1);
+        assert_eq!(r1, r0 + 1);
+    }
+
+    #[tokio::test]
+    async fn public_reconcile_forces_full_verification() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let (d0, r0) = svc.runtime.counters();
+
+        let stats = svc.reconcile().await.unwrap();
+        assert!(stats.discovered > 0);
+        let (d1, r1) = svc.runtime.counters();
+        assert_eq!(d1, d0 + 1);
+        assert_eq!(r1, r0 + 1);
+    }
+
+    #[tokio::test]
+    async fn verification_expiry_triggers_unknown_path_once() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let now = Instant::now();
+        svc.runtime.set_last_full_verified(
+            now - crate::runtime::FULL_VERIFY_INTERVAL - std::time::Duration::from_secs(1),
+        );
+        assert!(svc.runtime.is_verification_expired(now));
+
+        let (d0, r0) = svc.runtime.counters();
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res.stats.discovery_calls, Some(1));
+        assert_eq!(res.stats.runtime_state.as_deref(), Some("unknown"));
+        let (d1, r1) = svc.runtime.counters();
+        assert_eq!(d1, d0 + 1);
+        assert_eq!(r1, r0 + 1);
+
+        let res2 = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res2.stats.reconcile_skipped, Some(true));
+        let (d2, r2) = svc.runtime.counters();
+        assert_eq!(
+            (d2, r2),
+            (d1, r1),
+            "post-expiry clean search must not re-discover"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_during_reconcile_remains_dirty() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        fs::write(root.join("b.py"), b"def bar():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+
+        fs::write(root.join("a.py"), b"def foo():\n    return 1\n").unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+
+        let tracker = svc.runtime.tracker.clone();
+        svc.runtime.set_test_hook(Box::new(move || {
+            tracker.mark_paths(["b.py".to_string()]);
+        }));
+
+        let _ = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(
+            svc.runtime.state(),
+            RuntimeState::Dirty,
+            "event arriving during reconcile must leave runtime dirty"
+        );
+
+        let _ = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(svc.runtime.state(), RuntimeState::Clean);
     }
 }

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -2145,6 +2145,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn two_explicit_roots_have_isolated_runtime_state() {
+        let tmp1 = TempDir::new().unwrap();
+        let tmp2 = TempDir::new().unwrap();
+        let root1 = tmp1.path().to_path_buf();
+        let root2 = tmp2.path().to_path_buf();
+        fs::create_dir_all(root1.join(".git")).unwrap();
+        fs::create_dir_all(root2.join(".git")).unwrap();
+        fs::write(root1.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        fs::write(root2.join("b.py"), b"def bar():\n    pass\n").unwrap();
+
+        let svc1 = ContextService::new(Some(root1.clone())).await.unwrap();
+        let svc2 = ContextService::new(Some(root2.clone())).await.unwrap();
+
+        let snap1 = svc1.runtime.current_snapshot().unwrap();
+        let snap2 = svc2.runtime.current_snapshot().unwrap();
+        assert_ne!(snap1.project.root, snap2.project.root);
+        assert!(snap1
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "a.py"));
+        assert!(snap2
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "b.py"));
+        assert!(!snap1
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "b.py"));
+        assert!(!snap2
+            .project
+            .files
+            .iter()
+            .any(|f| f.relative_path == "a.py"));
+        assert_ne!(
+            Arc::as_ptr(&svc1.runtime) as *const (),
+            Arc::as_ptr(&svc2.runtime) as *const ()
+        );
+
+        svc1.runtime.tracker.mark_paths(["a.py".to_string()]);
+        assert_eq!(svc1.runtime.state(), RuntimeState::Dirty);
+        assert_eq!(svc2.runtime.state(), RuntimeState::Clean);
+        assert_eq!(
+            svc1.runtime.current_snapshot().unwrap().generation,
+            snap1.generation
+        );
+        assert_eq!(
+            svc2.runtime.current_snapshot().unwrap().generation,
+            snap2.generation
+        );
+    }
+
+    #[tokio::test]
     async fn dirty_expired_triggers_full_reconcile() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
 use context_core::ContextError;
 use context_index::embed::Embedder;
@@ -8,7 +9,7 @@ use context_index::structural::store as structural_store;
 use context_index::{ProjectIndex, ProjectRoot};
 
 use crate::pipeline::{retrieve_context, ContextResult, Providers};
-use crate::project::ProjectCache;
+use crate::runtime::{RepositoryRuntime, RuntimeState};
 
 /// Options for search-like calls.
 #[derive(Debug, Clone)]
@@ -101,15 +102,15 @@ pub struct StatusReport {
 
 /// Native service — single core for CLI and MCP.
 pub struct ContextService {
-    cache: Arc<ProjectCache>,
     root: PathBuf,
-    #[allow(dead_code)]
     explicit_root: Option<PathBuf>,
-    build_lock: Arc<tokio::sync::Mutex<()>>,
+    runtime: Arc<RepositoryRuntime>,
 }
 
 impl ContextService {
     /// Create service for given root (or auto-resolve via ProjectRoot::resolve).
+    /// Starts the mark-only watcher and completes one full discovery/reconcile
+    /// before returning so that the runtime snapshot is immediately usable.
     pub async fn new(root: Option<PathBuf>) -> Result<Self, ContextError> {
         let root_path = if let Some(p) = root.clone() {
             p.canonicalize().unwrap_or(p)
@@ -118,43 +119,58 @@ impl ContextService {
                 .map(|r| r.path().to_path_buf())
                 .map_err(|e| ContextError::InvalidRoot(e.to_string()))?
         };
-        Ok(Self {
-            cache: Arc::new(ProjectCache::new()),
+        let runtime = Arc::new(RepositoryRuntime::new(root_path.clone()).map_err(|e| {
+            ContextError::Internal(format!("failed to start repository runtime: {e}"))
+        })?);
+        let service = Self {
             root: root_path,
             explicit_root: root,
-            build_lock: Arc::new(tokio::sync::Mutex::new(())),
-        })
+            runtime,
+        };
+        service.initialize().await?;
+        Ok(service)
     }
 
-    /// For tests: create with explicit cache.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub fn with_cache(cache: Arc<ProjectCache>, root: PathBuf) -> Self {
-        Self {
-            cache,
-            root: root.clone(),
-            explicit_root: Some(root),
-            build_lock: Arc::new(tokio::sync::Mutex::new(())),
-        }
+    async fn initialize(&self) -> Result<(), ContextError> {
+        self.reconcile_and_publish(None).await?;
+        Ok(())
     }
 
-    async fn reconcile_inner(
+    async fn reconcile_and_publish(
         &self,
         override_embedder: Option<Arc<dyn Embedder>>,
-    ) -> Result<ReconcileStats, ContextError> {
-        self.reconcile_full_inner(override_embedder).await
+    ) -> Result<(ReconcileStats, Arc<ProjectIndex>, u128), ContextError> {
+        let _guard = self.runtime.reconcile_lock.lock().await;
+        self.reconcile_and_publish_locked(override_embedder).await
     }
 
-    async fn reconcile_full_inner(
+    /// Caller holds `runtime.reconcile_lock`; runtime data is locked only while publishing.
+    async fn reconcile_and_publish_locked(
         &self,
         override_embedder: Option<Arc<dyn Embedder>>,
-    ) -> Result<ReconcileStats, ContextError> {
-        let _guard = self.build_lock.lock().await;
-        let t0 = std::time::Instant::now();
+    ) -> Result<(ReconcileStats, Arc<ProjectIndex>, u128), ContextError> {
+        let epoch = self.runtime.tracker.snapshot().epoch;
+        let t0 = Instant::now();
         let root = ProjectRoot::resolve(Some(&self.root))
             .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
+
+        let fingerprint = override_embedder
+            .as_ref()
+            .map(|embedder| embedder.fingerprint())
+            .unwrap_or_else(context_index::embed::configured_fingerprint);
+        // Structural reconciliation mutates semantic references, so readiness must be sampled first.
+        let was_semantic_ready = structural_store::open_db(root.path())
+            .ok()
+            .and_then(|conn| {
+                context_index::vector::is_semantic_ready(&conn, &fingerprint, true).ok()
+            })
+            .unwrap_or(false);
+
+        let t_discovery = Instant::now();
+        self.runtime.increment_discovery();
         let idx =
             ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
+        let discovery_ms = t_discovery.elapsed().as_millis();
         let root_path = root.path().to_path_buf();
         let idx_clone = idx.clone();
         let outcome = tokio::task::spawn_blocking(move || {
@@ -165,130 +181,24 @@ impl ContextService {
         .map_err(|e| ContextError::Internal(format!("structural build panicked: {e}")))?
         .map_err(|e| ContextError::Internal(format!("structural build failed: {e}")))?;
 
-        let _elapsed_struct = t0.elapsed().as_millis();
-        let mut vectors_created = 0usize;
-        let mut vectors_reused = 0usize;
-        let mut embedding_calls = 0usize;
-
-        let fingerprint = if let Some(ref emb) = override_embedder {
-            emb.fingerprint()
-        } else {
-            context_index::embed::configured_fingerprint()
-        };
         let backend_available = if override_embedder.is_some() {
             true
         } else {
             context_index::embed::is_configured_model_available().await
         };
 
-        if backend_available {
-            let embedder: Arc<dyn Embedder> = if let Some(e) = override_embedder {
-                e
-            } else {
-                Arc::new(context_index::embed::configured_embedder())
-            };
-            match structural_store::open_db(root.path()) {
-                Ok(mut conn) => {
-                    match context_index::vector::sync_missing_vectors_for_root(
-                        &mut conn,
-                        root.path(),
-                        embedder.as_ref(),
-                    )
-                    .await
-                    {
-                        Ok((reused, created, calls, _docs)) => {
-                            vectors_reused = reused;
-                            vectors_created = created;
-                            embedding_calls = calls;
-                        }
-                        Err(e) => {
-                            tracing::warn!(error=%e, "semantic sync failed, structural still ok");
-                        }
-                    }
-                    let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
-                }
-                Err(e) => {
-                    tracing::warn!(error=%e, "open_db for semantic sync failed");
-                }
-            }
-        } else {
-            tracing::debug!("semantic backend unavailable, skipping vector sync");
-        }
-
-        let elapsed = t0.elapsed().as_millis();
-        Ok(ReconcileStats {
-            discovered: idx.stats.discovered,
-            changed_files: outcome.changed_files.len(),
-            deleted_files: outcome.deleted_files.len(),
-            elapsed_ms: elapsed,
-            vectors_created,
-            vectors_reused,
-            embedding_calls,
-        })
-    }
-
-    async fn reconcile_fast_inner(
-        &self,
-        override_embedder: Option<Arc<dyn Embedder>>,
-    ) -> Result<ReconcileStats, ContextError> {
-        let (stats, _idx, _discovery_ms) = self
-            .reconcile_fast_with_index_inner(override_embedder)
-            .await?;
-        Ok(stats)
-    }
-
-    async fn reconcile_fast_with_index_inner(
-        &self,
-        override_embedder: Option<Arc<dyn Embedder>>,
-    ) -> Result<(ReconcileStats, ProjectIndex, u128), ContextError> {
-        let _guard = self.build_lock.lock().await;
-        let t0 = std::time::Instant::now();
-        let root = ProjectRoot::resolve(Some(&self.root))
-            .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
-        // Capture semantic readiness BEFORE structural mutation (correct for incremental)
-        let fingerprint = if let Some(ref emb) = override_embedder {
-            emb.fingerprint()
-        } else {
-            context_index::embed::configured_fingerprint()
-        };
-        let was_semantic_ready = if let Ok(conn) = structural_store::open_db(root.path()) {
-            context_index::vector::is_semantic_ready(&conn, &fingerprint, true).unwrap_or(false)
-        } else {
-            false
-        };
-        let t_discover = std::time::Instant::now();
-        let idx =
-            ProjectIndex::discover(&root).map_err(|e| ContextError::Internal(e.to_string()))?;
-        let discovery_ms = t_discover.elapsed().as_millis();
-        let root_path = root.path().to_path_buf();
-        let idx_clone = idx.clone();
-        let outcome = tokio::task::spawn_blocking(move || {
-            let si = context_index::structural::StructuralIndex::for_path(root_path);
-            si.build_with_delta(&idx_clone)
-        })
-        .await
-        .map_err(|e| ContextError::Internal(format!("structural build panicked: {e}")))?
-        .map_err(|e| ContextError::Internal(format!("structural build failed: {e}")))?;
-
         let mut vectors_created = 0usize;
         let mut vectors_reused = 0usize;
         let mut embedding_calls = 0usize;
 
-        let backend_available = if override_embedder.is_some() {
-            true
-        } else {
-            context_index::embed::is_configured_model_available().await
-        };
-
         if backend_available {
-            let embedder: Arc<dyn Embedder> = if let Some(e) = override_embedder {
+            let embedder: Arc<dyn Embedder> = if let Some(e) = override_embedder.clone() {
                 e
             } else {
                 Arc::new(context_index::embed::configured_embedder())
             };
             match structural_store::open_db(root.path()) {
                 Ok(mut conn) => {
-                    // Fast path: only incremental when previously ready and small delta (using pre-mutation readiness)
                     let small_delta =
                         outcome.changed_files.len() <= 10 && outcome.deleted_files.len() <= 10;
                     if was_semantic_ready && small_delta && !outcome.changed_files.is_empty() {
@@ -309,23 +219,23 @@ impl ContextService {
                                 tracing::warn!(error=%e, "incremental semantic sync failed");
                             }
                         }
-                    } else {
-                        // Cold or no-change or large delta: do not full backfill, just GC if deleted
-                        if !outcome.deleted_files.is_empty() {
-                            let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
-                        }
                     }
-                    // Ensure GC for deleted files even when skipping embedding
                     if !outcome.deleted_files.is_empty() {
                         let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(error=%e, "open_db for fast semantic sync failed");
+                    tracing::warn!(error=%e, "open_db for semantic sync failed");
                 }
             }
+        } else {
+            tracing::debug!("semantic backend unavailable, skipping vector sync");
         }
 
+        let generation = structural_store::open_db(root.path())
+            .ok()
+            .and_then(|c| structural_store::get_generation(&c).ok())
+            .unwrap_or(0);
         let elapsed = t0.elapsed().as_millis();
         let stats = ReconcileStats {
             discovered: idx.stats.discovered,
@@ -336,7 +246,101 @@ impl ContextService {
             vectors_reused,
             embedding_calls,
         };
-        Ok((stats, idx, discovery_ms))
+        let project_arc = Arc::new(idx);
+        self.runtime
+            .publish(project_arc.clone(), generation, fingerprint, Instant::now());
+        self.runtime.tracker.acknowledge(epoch);
+        Ok((stats, project_arc, discovery_ms))
+    }
+
+    async fn reconcile_inner(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<ReconcileStats, ContextError> {
+        self.reconcile_full_inner(override_embedder).await
+    }
+
+    async fn reconcile_full_inner(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<ReconcileStats, ContextError> {
+        let _guard = self.runtime.reconcile_lock.lock().await;
+        let (mut stats, project, _) = self
+            .reconcile_and_publish_locked(override_embedder.clone())
+            .await?;
+        let backend_available = if override_embedder.is_some() {
+            true
+        } else {
+            context_index::embed::is_configured_model_available().await
+        };
+        if backend_available {
+            let embedder: Arc<dyn Embedder> = override_embedder
+                .unwrap_or_else(|| Arc::new(context_index::embed::configured_embedder()));
+            let fingerprint = embedder.fingerprint();
+            match structural_store::open_db(&project.root) {
+                Ok(mut conn) => {
+                    match context_index::vector::sync_missing_vectors_for_root(
+                        &mut conn,
+                        &project.root,
+                        embedder.as_ref(),
+                    )
+                    .await
+                    {
+                        Ok((reused, created, calls, _)) => {
+                            stats.vectors_reused += reused;
+                            stats.vectors_created += created;
+                            stats.embedding_calls += calls;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error=%e, "full semantic sync failed, structural still ok");
+                        }
+                    }
+                    let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
+                }
+                Err(e) => tracing::warn!(error=%e, "open_db for semantic sync failed"),
+            }
+        }
+        Ok(stats)
+    }
+
+    async fn reconcile_fast_inner(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<ReconcileStats, ContextError> {
+        let (stats, _, _) = self.reconcile_and_publish(override_embedder).await?;
+        Ok(stats)
+    }
+
+    async fn access_project(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<(Arc<ProjectIndex>, u128, ReconcileStats), ContextError> {
+        let _guard = self.runtime.reconcile_lock.lock().await;
+        let snapshot = self.runtime.current_snapshot();
+        if self.runtime.state() == RuntimeState::Clean
+            && !self.runtime.is_verification_expired(Instant::now())
+        {
+            let snapshot = snapshot.ok_or_else(|| {
+                ContextError::Internal("clean runtime has no project snapshot".into())
+            })?;
+            return Ok((
+                snapshot.project,
+                0,
+                ReconcileStats {
+                    discovered: 0,
+                    changed_files: 0,
+                    deleted_files: 0,
+                    elapsed_ms: 0,
+                    vectors_created: 0,
+                    vectors_reused: 0,
+                    embedding_calls: 0,
+                },
+            ));
+        }
+
+        let (stats, project, discovery_ms) =
+            self.reconcile_and_publish_locked(override_embedder).await?;
+        Ok((project, discovery_ms, stats))
     }
 
     /// Cheap reconcile — discovery + incremental structural/BM25 + semantic if available (fast, incremental only).
@@ -371,8 +375,8 @@ impl ContextService {
         opts: SearchOptions,
     ) -> Result<ContextResult, ContextError> {
         let t_search = std::time::Instant::now();
-        let (reconcile_stats, project, discovery_ms) = self
-            .reconcile_fast_with_index_inner(None)
+        let (project, discovery_ms, reconcile_stats) = self
+            .access_project(None)
             .await
             .map_err(|e| ContextError::Internal(format!("reconcile failed: {e}")))?;
         let providers = Providers {};
@@ -387,9 +391,10 @@ impl ContextService {
         .map_err(|e| ContextError::Internal(e.to_string()))?;
         // Fill stage telemetry at service layer
         let total_ms = t_search.elapsed().as_millis();
-        let generation = structural_store::open_db(&project.root)
-            .ok()
-            .and_then(|c| structural_store::get_generation(&c).ok());
+        let generation = self
+            .runtime
+            .current_snapshot()
+            .map(|snapshot| snapshot.generation);
         res.stats.total_ms = Some(total_ms);
         res.stats.discovery_ms = Some(discovery_ms);
         res.stats.reconcile_ms = Some(reconcile_stats.elapsed_ms);
@@ -863,17 +868,19 @@ mod tests {
         fs::create_dir_all(root.join(".git")).unwrap();
         fs::create_dir_all(root.join(".context")).unwrap();
         fs::write(root.join(".context/index"), b"not a directory").unwrap();
-        let svc = ContextService::new(Some(root.clone())).await.unwrap();
-        let res = svc.search("foo", SearchOptions::default()).await;
+        let res = ContextService::new(Some(root.clone())).await;
         assert!(
             res.is_err(),
-            "search should propagate reconcile failure, got {:?}",
-            res
+            "initialization should propagate reconcile failure"
         );
-        let err = res.unwrap_err().to_string().to_lowercase();
+        let err = res
+            .err()
+            .expect("initialization error")
+            .to_string()
+            .to_lowercase();
         assert!(
-            err.contains("reconcile"),
-            "error should mention reconcile, got: {}",
+            err.contains("structural build"),
+            "error should mention the failed build, got: {}",
             err
         );
     }
@@ -1215,18 +1222,19 @@ mod tests {
         std::fs::create_dir_all(root.join(".context")).unwrap();
         // Make .context/index a file to cause DB open failure
         std::fs::write(root.join(".context/index"), b"not a directory").unwrap();
-        let svc = ContextService::new(Some(root.clone())).await.unwrap();
-        let res = svc
-            .dependency("foo", Direction::Callers, SearchOptions::default())
-            .await;
+        let res = ContextService::new(Some(root.clone())).await;
         assert!(
             res.is_err(),
-            "dependency should return error on DB failure, not panic"
+            "service initialization should return DB failure, not panic"
         );
-        let err = res.unwrap_err().to_string().to_lowercase();
+        let err = res
+            .err()
+            .expect("initialization error")
+            .to_string()
+            .to_lowercase();
         assert!(
-            err.contains("open_db") || err.contains("reconcile") || err.contains("internal"),
-            "error should mention open_db/reconcile, got: {}",
+            err.contains("structural build"),
+            "error should mention the failed build, got: {}",
             err
         );
     }
@@ -1295,6 +1303,23 @@ mod tests {
                 key
             );
         }
+    }
+
+    #[tokio::test]
+    async fn runtime_initial() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+        let (d, r) = svc.runtime.counters();
+        assert_eq!(d, 1, "initialization should perform one discovery");
+        assert_eq!(r, 1, "initialization should perform one reconcile");
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert!(!res.evidence.is_empty(), "search should find foo");
+        let (d2, r2) = svc.runtime.counters();
+        assert_eq!(d2, 1, "clean search should not discover again");
+        assert_eq!(r2, 1, "clean search should not reconcile again");
     }
 
     #[tokio::test]

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -329,7 +329,6 @@ impl ContextService {
         if backend_available {
             let embedder: Arc<dyn Embedder> = override_embedder
                 .unwrap_or_else(|| Arc::new(context_index::embed::configured_embedder()));
-            let fingerprint = embedder.fingerprint();
             match structural_store::open_db(&full.project.root) {
                 Ok(mut conn) => {
                     match context_index::vector::sync_missing_vectors_for_root(
@@ -348,10 +347,14 @@ impl ContextService {
                             tracing::warn!(error=%e, "full semantic sync failed, structural still ok");
                         }
                     }
-                    let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
                 }
                 Err(e) => tracing::warn!(error=%e, "open_db for semantic sync failed"),
             }
+        }
+        // Orphan GC is a local SQLite DELETE and must not be gated on the
+        // embedding backend (NF2). Use the full discovery fingerprint.
+        if let Ok(conn) = structural_store::open_db(&full.project.root) {
+            let _ = context_index::vector::gc_orphaned_vectors(&conn, &full.fingerprint);
         }
         // Publish the clean replacement snapshot only after the full semantic
         // backfill has completed (F6).
@@ -388,8 +391,9 @@ impl ContextService {
         // cannot split them (F1/F2).
         let access = self.runtime.dirty_access();
         let has_snapshot = self.runtime.current_snapshot().is_some();
+        let expired = self.runtime.is_verification_expired(now);
 
-        if access.state == RuntimeState::Clean && !self.runtime.is_verification_expired(now) {
+        if access.state == RuntimeState::Clean && !expired {
             let snapshot = self.runtime.current_snapshot().ok_or_else(|| {
                 ContextError::Internal("clean runtime has no project snapshot".into())
             })?;
@@ -406,34 +410,41 @@ impl ContextService {
             });
         }
 
-        if let Some(paths) = access.paths {
-            if has_snapshot {
-                let dirty_count = paths.len();
-                #[cfg(test)]
-                self.runtime.run_pre_reconcile_hook();
-                let (stats, project) = self
-                    .reconcile_dirty_paths_locked(override_embedder, &paths, access.epoch)
-                    .await?;
-                let generation = self
-                    .runtime
-                    .current_snapshot()
-                    .map(|s| s.generation)
-                    .unwrap_or(0);
-                return Ok(RuntimeAccess {
-                    project,
-                    generation,
-                    reconcile_skipped: false,
-                    discovery_calls: 0,
-                    reconcile_calls: 1,
-                    runtime_state: "dirty",
-                    dirty_file_count: Some(dirty_count),
-                    discovery_ms: 0,
-                    reconcile_ms: stats.elapsed_ms,
-                });
+        // Expired verification dominates DirtyState::Paths (NF1): every
+        // expired request performs exactly one full discovery/reconcile with
+        // runtime_state unknown, discovery_calls 1, reconcile_calls 1,
+        // dirty_file_count None.
+        if !expired {
+            if let Some(paths) = access.paths {
+                if has_snapshot {
+                    let dirty_count = paths.len();
+                    #[cfg(test)]
+                    self.runtime.run_pre_reconcile_hook();
+                    let (stats, project) = self
+                        .reconcile_dirty_paths_locked(override_embedder, &paths, access.epoch)
+                        .await?;
+                    let generation = self
+                        .runtime
+                        .current_snapshot()
+                        .map(|s| s.generation)
+                        .unwrap_or(0);
+                    return Ok(RuntimeAccess {
+                        project,
+                        generation,
+                        reconcile_skipped: false,
+                        discovery_calls: 0,
+                        reconcile_calls: 1,
+                        runtime_state: "dirty",
+                        dirty_file_count: Some(dirty_count),
+                        discovery_ms: 0,
+                        reconcile_ms: stats.elapsed_ms,
+                    });
+                }
             }
         }
 
-        // Unknown, expired, or dirty-without-snapshot: one full discovery/reconcile.
+        // Unknown, expired (including Dirty+expired), or dirty-without-snapshot:
+        // one full discovery/reconcile.
         let (stats, project, discovery_ms) =
             self.reconcile_and_publish_locked(override_embedder).await?;
         let generation = self
@@ -2088,14 +2099,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn path_local_reconcile_preserves_verification_deadline() {
+    async fn dirty_path_local_preserves_verification_deadline() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
         fs::create_dir_all(root.join(".git")).unwrap();
         fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
         let svc = ContextService::new(Some(root.clone())).await.unwrap();
 
-        // Force the full-verification deadline into the past.
+        // Non-expired deadline: 10s remaining.
+        let base = Instant::now() - crate::runtime::FULL_VERIFY_INTERVAL
+            + std::time::Duration::from_secs(10);
+        svc.runtime.set_last_full_verified(base);
+        let now = Instant::now();
+        assert!(
+            !svc.runtime.is_verification_expired(now),
+            "deadline should not be expired yet"
+        );
+
+        fs::write(root.join("a.py"), b"def foo():\n    return 2\n").unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res.stats.discovery_calls, Some(0));
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+        assert_eq!(res.stats.runtime_state.as_deref(), Some("dirty"));
+        assert_eq!(res.stats.dirty_file_count, Some(1));
+
+        // Path-local publish must not refresh the full-verification deadline.
+        // Synthetic instant just beyond the original deadline distinguishes
+        // preservation (expired) from a reset to now (not expired).
+        let synthetic =
+            base + crate::runtime::FULL_VERIFY_INTERVAL + std::time::Duration::from_secs(1);
+        assert!(
+            svc.runtime.is_verification_expired(synthetic),
+            "path-local publish must not reset the full-verification deadline"
+        );
+        assert!(
+            !svc.runtime.is_verification_expired(now),
+            "still not expired at the original now"
+        );
+    }
+
+    #[tokio::test]
+    async fn dirty_expired_triggers_full_reconcile() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+
         let now = Instant::now();
         svc.runtime.set_last_full_verified(
             now - crate::runtime::FULL_VERIFY_INTERVAL - std::time::Duration::from_secs(1),
@@ -2106,13 +2158,21 @@ mod tests {
         svc.runtime.tracker.mark_paths(["a.py".to_string()]);
 
         let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(
+            res.stats.discovery_calls,
+            Some(1),
+            "dirty+expired must perform exactly one full discovery"
+        );
         assert_eq!(res.stats.reconcile_calls, Some(1));
-        assert_eq!(res.stats.runtime_state.as_deref(), Some("dirty"));
+        assert_eq!(res.stats.runtime_state.as_deref(), Some("unknown"));
+        assert_eq!(
+            res.stats.dirty_file_count, None,
+            "expired fallback must report null dirty_file_count"
+        );
 
-        // Path-local publish must not refresh the full-verification deadline (F4).
         assert!(
-            svc.runtime.is_verification_expired(now),
-            "path-local publish must not reset the full-verification deadline"
+            !svc.runtime.is_verification_expired(Instant::now()),
+            "full discovery must clear the expired deadline"
         );
     }
 }

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -78,9 +78,19 @@ pub(crate) struct RuntimeAccess {
     pub discovery_calls: u32,
     pub reconcile_calls: u32,
     pub runtime_state: &'static str,
-    pub dirty_file_count: usize,
+    pub dirty_file_count: Option<usize>,
     pub discovery_ms: u128,
     pub reconcile_ms: u128,
+}
+
+/// Result of one full discovery + structural build, before any publish/ack.
+struct FullReconcile {
+    stats: ReconcileStats,
+    project: Arc<ProjectIndex>,
+    discovery_ms: u128,
+    fingerprint: context_index::embed::ModelFingerprint,
+    generation: u64,
+    epoch: u64,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -160,10 +170,10 @@ impl ContextService {
     }
 
     /// Caller holds `runtime.reconcile_lock`; runtime data is locked only while publishing.
-    async fn reconcile_and_publish_locked(
+    async fn reconcile_full_discovery_locked(
         &self,
         override_embedder: Option<Arc<dyn Embedder>>,
-    ) -> Result<(ReconcileStats, Arc<ProjectIndex>, u128), ContextError> {
+    ) -> Result<FullReconcile, ContextError> {
         let epoch = self.runtime.tracker.snapshot().epoch;
         let t0 = Instant::now();
         let root = ProjectRoot::resolve(Some(&self.root))
@@ -235,9 +245,6 @@ impl ContextService {
                             }
                         }
                     }
-                    if !outcome.deleted_files.is_empty() {
-                        let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
-                    }
                 }
                 Err(e) => {
                     tracing::warn!(error=%e, "open_db for semantic sync failed");
@@ -245,6 +252,14 @@ impl ContextService {
             }
         } else {
             tracing::debug!("semantic backend unavailable, skipping vector sync");
+        }
+
+        // Orphan GC after deletion is a local SQLite DELETE, independent of the
+        // embedding backend (F5).
+        if !outcome.deleted_files.is_empty() {
+            if let Ok(conn) = structural_store::open_db(root.path()) {
+                let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
+            }
         }
 
         let generation = structural_store::open_db(root.path())
@@ -261,13 +276,34 @@ impl ContextService {
             vectors_reused,
             embedding_calls,
         };
-        let project_arc = Arc::new(idx);
-        self.runtime
-            .publish(project_arc.clone(), generation, fingerprint, Instant::now());
+        Ok(FullReconcile {
+            stats,
+            project: Arc::new(idx),
+            discovery_ms,
+            fingerprint,
+            generation,
+            epoch,
+        })
+    }
+
+    async fn reconcile_and_publish_locked(
+        &self,
+        override_embedder: Option<Arc<dyn Embedder>>,
+    ) -> Result<(ReconcileStats, Arc<ProjectIndex>, u128), ContextError> {
+        let full = self
+            .reconcile_full_discovery_locked(override_embedder)
+            .await?;
+        self.runtime.publish(
+            full.project.clone(),
+            full.generation,
+            full.fingerprint.clone(),
+            Instant::now(),
+            true,
+        );
         #[cfg(test)]
         self.runtime.run_test_hook();
-        self.runtime.tracker.acknowledge(epoch);
-        Ok((stats, project_arc, discovery_ms))
+        self.runtime.tracker.acknowledge(full.epoch);
+        Ok((full.stats, full.project, full.discovery_ms))
     }
 
     async fn reconcile_inner(
@@ -282,8 +318,8 @@ impl ContextService {
         override_embedder: Option<Arc<dyn Embedder>>,
     ) -> Result<ReconcileStats, ContextError> {
         let _guard = self.runtime.reconcile_lock.lock().await;
-        let (mut stats, project, _) = self
-            .reconcile_and_publish_locked(override_embedder.clone())
+        let mut full = self
+            .reconcile_full_discovery_locked(override_embedder.clone())
             .await?;
         let backend_available = if override_embedder.is_some() {
             true
@@ -294,19 +330,19 @@ impl ContextService {
             let embedder: Arc<dyn Embedder> = override_embedder
                 .unwrap_or_else(|| Arc::new(context_index::embed::configured_embedder()));
             let fingerprint = embedder.fingerprint();
-            match structural_store::open_db(&project.root) {
+            match structural_store::open_db(&full.project.root) {
                 Ok(mut conn) => {
                     match context_index::vector::sync_missing_vectors_for_root(
                         &mut conn,
-                        &project.root,
+                        &full.project.root,
                         embedder.as_ref(),
                     )
                     .await
                     {
                         Ok((reused, created, calls, _)) => {
-                            stats.vectors_reused += reused;
-                            stats.vectors_created += created;
-                            stats.embedding_calls += calls;
+                            full.stats.vectors_reused += reused;
+                            full.stats.vectors_created += created;
+                            full.stats.embedding_calls += calls;
                         }
                         Err(e) => {
                             tracing::warn!(error=%e, "full semantic sync failed, structural still ok");
@@ -317,7 +353,19 @@ impl ContextService {
                 Err(e) => tracing::warn!(error=%e, "open_db for semantic sync failed"),
             }
         }
-        Ok(stats)
+        // Publish the clean replacement snapshot only after the full semantic
+        // backfill has completed (F6).
+        self.runtime.publish(
+            full.project.clone(),
+            full.generation,
+            full.fingerprint.clone(),
+            Instant::now(),
+            true,
+        );
+        #[cfg(test)]
+        self.runtime.run_test_hook();
+        self.runtime.tracker.acknowledge(full.epoch);
+        Ok(full.stats)
     }
 
     async fn reconcile_fast_inner(
@@ -336,11 +384,12 @@ impl ContextService {
     ) -> Result<RuntimeAccess, ContextError> {
         let _guard = self.runtime.reconcile_lock.lock().await;
         let now = Instant::now();
-        let state = self.runtime.state();
-        let dirty = self.runtime.dirty_paths();
+        // One snapshot for state + paths + epoch so a concurrent watcher event
+        // cannot split them (F1/F2).
+        let access = self.runtime.dirty_access();
         let has_snapshot = self.runtime.current_snapshot().is_some();
 
-        if state == RuntimeState::Clean && !self.runtime.is_verification_expired(now) {
+        if access.state == RuntimeState::Clean && !self.runtime.is_verification_expired(now) {
             let snapshot = self.runtime.current_snapshot().ok_or_else(|| {
                 ContextError::Internal("clean runtime has no project snapshot".into())
             })?;
@@ -351,17 +400,19 @@ impl ContextService {
                 discovery_calls: 0,
                 reconcile_calls: 0,
                 runtime_state: "clean",
-                dirty_file_count: 0,
+                dirty_file_count: Some(0),
                 discovery_ms: 0,
                 reconcile_ms: 0,
             });
         }
 
-        if let Some(paths) = dirty {
+        if let Some(paths) = access.paths {
             if has_snapshot {
                 let dirty_count = paths.len();
+                #[cfg(test)]
+                self.runtime.run_pre_reconcile_hook();
                 let (stats, project) = self
-                    .reconcile_dirty_paths_locked(override_embedder, &paths)
+                    .reconcile_dirty_paths_locked(override_embedder, &paths, access.epoch)
                     .await?;
                 let generation = self
                     .runtime
@@ -375,7 +426,7 @@ impl ContextService {
                     discovery_calls: 0,
                     reconcile_calls: 1,
                     runtime_state: "dirty",
-                    dirty_file_count: dirty_count,
+                    dirty_file_count: Some(dirty_count),
                     discovery_ms: 0,
                     reconcile_ms: stats.elapsed_ms,
                 });
@@ -397,7 +448,7 @@ impl ContextService {
             discovery_calls: 1,
             reconcile_calls: 1,
             runtime_state: "unknown",
-            dirty_file_count: 0,
+            dirty_file_count: None,
             discovery_ms,
             reconcile_ms: stats.elapsed_ms,
         })
@@ -410,16 +461,20 @@ impl ContextService {
         &self,
         override_embedder: Option<Arc<dyn Embedder>>,
         paths: &BTreeSet<String>,
+        epoch: u64,
     ) -> Result<(ReconcileStats, Arc<ProjectIndex>), ContextError> {
-        let epoch = self.runtime.tracker.snapshot().epoch;
         let t0 = Instant::now();
         let root = ProjectRoot::resolve(Some(&self.root))
             .map_err(|e| ContextError::InvalidRoot(e.to_string()))?;
 
+        // Fingerprint of the model actually in use: the override when supplied,
+        // else the runtime's published semantic fingerprint (set by the last
+        // full/initial reconcile). This keeps orphan GC targeted at the vectors
+        // that were really created, not always the configured model (F5).
         let fingerprint = override_embedder
             .as_ref()
             .map(|e| e.fingerprint())
-            .unwrap_or_else(context_index::embed::configured_fingerprint);
+            .unwrap_or_else(|| self.runtime.semantic_fingerprint());
         // Structural mutation may change semantic refs; sample readiness first.
         let was_semantic_ready = structural_store::open_db(root.path())
             .ok()
@@ -506,11 +561,17 @@ impl ContextService {
                             Err(e) => tracing::warn!(error=%e, "incremental semantic sync failed"),
                         }
                     }
-                    if !removed.is_empty() {
-                        let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
-                    }
                 }
                 Err(e) => tracing::warn!(error=%e, "open_db for semantic sync failed"),
+            }
+        }
+
+        // Orphan GC is a local SQLite DELETE independent of the embedding backend;
+        // it must run after any deletion with the fingerprint of the model actually
+        // in use (F5).
+        if !removed.is_empty() {
+            if let Ok(conn) = structural_store::open_db(root.path()) {
+                let _ = context_index::vector::gc_orphaned_vectors(&conn, &fingerprint);
             }
         }
 
@@ -558,8 +619,13 @@ impl ContextService {
             embedding_calls,
         };
         let project_arc = Arc::new(delta.project);
-        self.runtime
-            .publish(project_arc.clone(), generation, fingerprint, Instant::now());
+        self.runtime.publish(
+            project_arc.clone(),
+            generation,
+            fingerprint,
+            Instant::now(),
+            false,
+        );
         #[cfg(test)]
         self.runtime.run_test_hook();
         self.runtime.tracker.acknowledge(epoch);
@@ -627,7 +693,7 @@ impl ContextService {
         res.stats.discovery_ms = Some(access.discovery_ms);
         res.stats.reconcile_ms = Some(access.reconcile_ms);
         res.stats.generation = Some(access.generation);
-        res.stats.dirty_file_count = Some(access.dirty_file_count);
+        res.stats.dirty_file_count = access.dirty_file_count;
         res.stats.reconcile_skipped = Some(access.reconcile_skipped);
         res.stats.discovery_calls = Some(access.discovery_calls);
         res.stats.reconcile_calls = Some(access.reconcile_calls);
@@ -930,7 +996,7 @@ impl ContextService {
             fusion_ms: Some(fuse_ms),
             authority_ms: Some(rank_ms),
             generation: Some(access.generation),
-            dirty_file_count: Some(access.dirty_file_count),
+            dirty_file_count: access.dirty_file_count,
             vector_count_scanned: None,
             cache_hit: None,
             reconcile_skipped: Some(access.reconcile_skipped),
@@ -1877,12 +1943,19 @@ mod tests {
             "unrelated vectors must remain"
         );
 
-        // Delete a.py: semantic refs disappear, remaining files stay ready.
+        // Delete a.py: semantic refs disappear, orphan vectors GC'd (F5), remaining files stay ready.
         fs::remove_file(root.join("a.py")).unwrap();
         svc.runtime.tracker.mark_paths(["a.py".to_string()]);
         let _ = svc.search("foo", SearchOptions::default()).await.unwrap();
         let conn3 = structural_store::open_db(&root).unwrap();
         assert!(context_index::vector::is_semantic_ready(&conn3, &fp, true).unwrap());
+        let vectors_after_delete = context_index::vector::count_vectors(&conn3, &fp).unwrap();
+        assert!(
+            vectors_after_delete < vectors_after,
+            "orphan vectors for the deleted file must be GC'd: {} -> {}",
+            vectors_after,
+            vectors_after_delete
+        );
     }
 
     #[tokio::test]
@@ -1899,6 +1972,10 @@ mod tests {
         assert_eq!(res.stats.discovery_calls, Some(1));
         assert_eq!(res.stats.reconcile_calls, Some(1));
         assert_eq!(res.stats.runtime_state.as_deref(), Some("unknown"));
+        assert_eq!(
+            res.stats.dirty_file_count, None,
+            "Unknown must report null dirty_file_count, not a fake zero"
+        );
         let (d1, r1) = svc.runtime.counters();
         assert_eq!(d1, d0 + 1);
         assert_eq!(r1, r0 + 1);
@@ -1977,5 +2054,65 @@ mod tests {
 
         let _ = svc.search("foo", SearchOptions::default()).await.unwrap();
         assert_eq!(svc.runtime.state(), RuntimeState::Clean);
+    }
+
+    #[tokio::test]
+    async fn event_between_snapshot_and_reconcile_remains_dirty() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        fs::write(root.join("b.py"), b"def bar():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+
+        fs::write(root.join("a.py"), b"def foo():\n    return 1\n").unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+
+        // Inject a second event in the F1 window: after `dirty_access()` captured
+        // {a.py}+epoch, but before the path-local reconcile acknowledges.
+        let tracker = svc.runtime.tracker.clone();
+        svc.runtime.set_pre_reconcile_hook(Box::new(move || {
+            tracker.mark_paths(["b.py".to_string()]);
+        }));
+
+        let _ = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(
+            svc.runtime.state(),
+            RuntimeState::Dirty,
+            "event between snapshot capture and reconcile must not be acknowledged away"
+        );
+
+        // The second path is reconciled on the next request.
+        let _ = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(svc.runtime.state(), RuntimeState::Clean);
+    }
+
+    #[tokio::test]
+    async fn path_local_reconcile_preserves_verification_deadline() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("a.py"), b"def foo():\n    pass\n").unwrap();
+        let svc = ContextService::new(Some(root.clone())).await.unwrap();
+
+        // Force the full-verification deadline into the past.
+        let now = Instant::now();
+        svc.runtime.set_last_full_verified(
+            now - crate::runtime::FULL_VERIFY_INTERVAL - std::time::Duration::from_secs(1),
+        );
+        assert!(svc.runtime.is_verification_expired(now));
+
+        fs::write(root.join("a.py"), b"def foo():\n    return 2\n").unwrap();
+        svc.runtime.tracker.mark_paths(["a.py".to_string()]);
+
+        let res = svc.search("foo", SearchOptions::default()).await.unwrap();
+        assert_eq!(res.stats.reconcile_calls, Some(1));
+        assert_eq!(res.stats.runtime_state.as_deref(), Some("dirty"));
+
+        // Path-local publish must not refresh the full-verification deadline (F4).
+        assert!(
+            svc.runtime.is_verification_expired(now),
+            "path-local publish must not reset the full-verification deadline"
+        );
     }
 }

--- a/crates/contextd/src/service.rs
+++ b/crates/contextd/src/service.rs
@@ -206,8 +206,11 @@ impl ContextService {
         .map_err(|e| ContextError::Internal(format!("structural build panicked: {e}")))?
         .map_err(|e| ContextError::Internal(format!("structural build failed: {e}")))?;
 
+        let needs_incremental_semantic = was_semantic_ready && !outcome.changed_files.is_empty();
         let backend_available = if override_embedder.is_some() {
             true
+        } else if !needs_incremental_semantic {
+            false
         } else {
             context_index::embed::is_configured_model_available().await
         };
@@ -1337,11 +1340,12 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     async fn daemon_reachable_model_unavailable_reports_unavailable() {
         let _env_guard = ENV_GLOBAL_LOCK.lock().unwrap();
-        // mock Ollama tags server - handle 2 requests
+        // Mock Ollama tags server until the test aborts it. Extra probes should not
+        // make the second model check fail by exhausting the fixture.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
-            for _ in 0..2 {
+            loop {
                 if let Ok((mut socket, _)) = listener.accept().await {
                     let mut buf = [0u8; 2048];
                     let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;

--- a/docs/superpowers/plans/2026-08-18-r5.1-e2-persistent-runtime.md
+++ b/docs/superpowers/plans/2026-08-18-r5.1-e2-persistent-runtime.md
@@ -1,0 +1,556 @@
+# R5.1-E2 Persistent Repository Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist a validated repository snapshot in `ContextService` so unchanged MCP searches perform zero repository discoveries and zero reconciles while changed paths reconcile safely and incrementally.
+
+**Architecture:** Add a mark-only watcher with epoch-based acknowledgement, a path-local `ProjectIndex` refresh API, and a repository-scoped `RepositoryRuntime` owned by `ContextService`. Initialization and unknown fallback perform full discovery; clean searches clone an `Arc<ProjectIndex>`; dirty searches serialize once and reuse existing single-file structural, BM25, graph, and semantic APIs.
+
+**Tech Stack:** Rust 2021, Tokio, notify 8, rusqlite/WAL, existing `context-index`, `contextd`, Python benchmark harness, persistent MCP JSON-RPC.
+
+## Global Constraints
+
+- Base commit is `6cdb92ebe14939568cf0339138e7c0b5d283c011` on `r5.1/e2-persistent-runtime`.
+- Production remains Rust; Python remains benchmark/support tooling only.
+- Do not add result caching, ANN/HNSW, hot vector storage, LSP/SCIP, ranking changes, or E3 work.
+- Preserve exact, symbol, test, dependency, conceptual fusion, authority, all-minilm 384d, representation v2, and ground-truth behavior.
+- One runtime belongs to one explicit canonical root/worktree; no global mutable repository singleton.
+- Never share a rusqlite `Connection` across threads or hold an active SQLite transaction across embedding HTTP awaits.
+- Existing untracked `bench/` artifacts and pinned repositories must not be staged or damaged.
+- Clean hot telemetry must be explicit: zero discovery calls, zero reconcile calls, and `reconcile_skipped=true`.
+- Unknown state may perform full discovery only for initialization, watcher uncertainty, explicit reconcile/full indexing, and bounded verification.
+
+## File Map
+
+- Modify `crates/context-index/src/watcher.rs`: add mark-only dirty tracker/watcher without changing existing `StructuralWatcher` behavior.
+- Modify `crates/context-index/src/discovery.rs`: factor one-file discovery and add deterministic path-local snapshot refresh.
+- Create `crates/contextd/src/runtime.rs`: own repository snapshot, generation, semantic fingerprint, watcher state, verification deadline, and reconcile mutex.
+- Modify `crates/contextd/src/lib.rs` and `crates/contextd/src/main.rs`: register the runtime module.
+- Modify `crates/contextd/src/service.rs`: initialize and consume the runtime, implement clean/dirty/unknown paths, preserve semantic correctness, and remove dead `ProjectCache` ownership.
+- Modify `crates/contextd/src/pipeline.rs`: add explicit E2 telemetry fields.
+- Modify `bench/adapters/interface.py`, `bench/adapters/context_engine.py`, and `bench/adapters/context_engine_hot.py`: preserve new telemetry in benchmark records.
+- Modify `bench/tests/test_run.py`: assert the benchmark adapter carries explicit E2 counters without inference.
+
+---
+
+### Task 1: Mark-Only Dirty Tracking
+
+**Files:**
+- Modify: `crates/context-index/src/watcher.rs`
+
+**Interfaces:**
+- Produces: `DirtyState`, `DirtySnapshot`, `DirtyTracker`, and `RepositoryWatcher`.
+- `DirtyTracker::snapshot() -> DirtySnapshot` returns state plus epoch without clearing it.
+- `DirtyTracker::acknowledge(epoch: u64)` clears only an unchanged epoch.
+- `DirtyTracker::mark_paths(...)` and `mark_unknown()` are deterministic injection points used by the notify callback and service tests.
+
+- [ ] **Step 1: Add failing epoch and overflow tests**
+
+Append tests that establish the state contract before implementation:
+
+```rust
+#[test]
+fn dirty_ack_does_not_lose_event_during_reconcile() {
+    let tracker = DirtyTracker::new(2);
+    tracker.mark_paths(["src/a.rs"]);
+    let snapshot = tracker.snapshot();
+    tracker.mark_paths(["src/a.rs"]);
+    tracker.acknowledge(snapshot.epoch);
+    assert_eq!(tracker.snapshot().state, DirtyState::Dirty(BTreeSet::from(["src/a.rs".into()])));
+}
+
+#[test]
+fn dirty_capacity_overflow_becomes_unknown() {
+    let tracker = DirtyTracker::new(1);
+    tracker.mark_paths(["src/a.rs", "src/b.rs"]);
+    assert_eq!(tracker.snapshot().state, DirtyState::Unknown);
+}
+
+#[test]
+fn dirty_ack_clears_unchanged_epoch() {
+    let tracker = DirtyTracker::new(8);
+    tracker.mark_paths(["src/a.rs"]);
+    let snapshot = tracker.snapshot();
+    tracker.acknowledge(snapshot.epoch);
+    assert_eq!(tracker.snapshot().state, DirtyState::Clean);
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm red**
+
+Run: `cargo test -p context-index watcher::tests::dirty_ -- --nocapture`
+
+Expected: compile failure because `DirtyTracker` and `DirtyState` do not exist.
+
+- [ ] **Step 3: Implement bounded epoch state**
+
+Add these public data types using `std::sync::Mutex` so notify callbacks never require a Tokio runtime:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirtyState {
+    Clean,
+    Dirty(BTreeSet<String>),
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirtySnapshot {
+    pub epoch: u64,
+    pub state: DirtyState,
+}
+
+#[derive(Clone)]
+pub struct DirtyTracker {
+    inner: Arc<std::sync::Mutex<DirtyInner>>,
+    capacity: usize,
+}
+
+struct DirtyInner {
+    epoch: u64,
+    state: DirtyState,
+}
+```
+
+Implement `snapshot`, `mark_paths`, `mark_unknown`, and `acknowledge`. Every mark increments `epoch`. If the mutex is poisoned, `snapshot` must return `Unknown`; it must never report false cleanliness.
+
+- [ ] **Step 4: Add failing watcher classification test**
+
+Create a temporary repository, start `RepositoryWatcher`, modify a regular source file, and wait with a bounded timeout until its tracker reports that relative path. Modify `.gitignore` and assert `Unknown`. The test must fail before `RepositoryWatcher` exists.
+
+- [ ] **Step 5: Implement `RepositoryWatcher`**
+
+Use `notify::recommended_watcher` and retain the handle:
+
+```rust
+pub struct RepositoryWatcher {
+    root: PathBuf,
+    tracker: DirtyTracker,
+    _watcher: RecommendedWatcher,
+}
+
+impl RepositoryWatcher {
+    pub fn new(root: PathBuf) -> Result<Self>;
+    pub fn tracker(&self) -> DirtyTracker;
+    pub fn root(&self) -> &Path;
+}
+```
+
+The callback only normalizes and records paths. It marks `Unknown` for notify errors, ignore-control files, directory events, unnormalizable paths, or capacity overflow. It performs no SQLite, parsing, hashing, or embedding work. Preserve all existing `StructuralWatcher` code and tests.
+
+- [ ] **Step 6: Run watcher tests**
+
+Run: `cargo test -p context-index watcher::tests -- --nocapture`
+
+Expected: all existing and new watcher tests pass.
+
+- [ ] **Step 7: Commit the watcher primitive**
+
+```bash
+git add crates/context-index/src/watcher.rs
+git commit -m "R5.1-E2 add mark-only repository watcher"
+```
+
+---
+
+### Task 2: Path-Local Project Snapshot Refresh
+
+**Files:**
+- Modify: `crates/context-index/src/discovery.rs`
+
+**Interfaces:**
+- Produces: `ProjectIndexDelta { project, changed_files, deleted_files }`.
+- Produces: `ProjectIndex::refresh_paths(&self, paths: &BTreeSet<String>) -> Result<ProjectIndexDelta, ContextError>`.
+- Task 3 consumes the returned replacement project and actual delta.
+
+- [ ] **Step 1: Add failing refresh tests**
+
+Add tests for create, modify, delete, unrelated-file stability, deterministic ordering, and scan-stat recomputation:
+
+```rust
+#[test]
+fn refresh_paths_only_rehashes_supplied_files() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "fn b() {}").unwrap();
+    let root = ProjectRoot::new(dir.path()).unwrap();
+    let initial = ProjectIndex::discover(&root).unwrap();
+    let old_b = initial.find_by_path("b.rs").unwrap().content_hash.clone();
+    std::fs::write(dir.path().join("a.rs"), "fn changed() {}").unwrap();
+    let delta = initial.refresh_paths(&BTreeSet::from(["a.rs".into()])).unwrap();
+    assert_eq!(delta.changed_files, vec!["a.rs"]);
+    assert_eq!(delta.project.find_by_path("b.rs").unwrap().content_hash, old_b);
+}
+```
+
+Include a delete test asserting `deleted_files == [path]` and no remaining record.
+
+- [ ] **Step 2: Run focused discovery tests and confirm red**
+
+Run: `cargo test -p context-index discovery::tests::refresh_paths -- --nocapture`
+
+Expected: compile failure because `refresh_paths` does not exist.
+
+- [ ] **Step 3: Factor one-file record creation from full discovery**
+
+Extract a private helper used by both the full walk and path refresh:
+
+```rust
+fn file_record(root: &Path, path: &Path, do_hash: bool, stats: &mut ScanStats) -> Option<FileRecord>
+```
+
+It must preserve current canonical relative paths, internal/generated exclusion, classification, size cap, text-searchability, metadata, hash-error accounting, and stats behavior.
+
+- [ ] **Step 4: Implement deterministic `refresh_paths`**
+
+Clone the existing file vector once, binary-search each sorted path, remove deleted/excluded records, replace changed records, insert created records, sort once, and recompute aggregate `ScanStats` from the final vector. Compare kind, size, modified time, and content hash to avoid reporting no-change events as mutations.
+
+Return sorted `changed_files` and `deleted_files`. Do not walk directories or inspect unrelated files.
+
+- [ ] **Step 5: Run discovery and exact-search tests**
+
+Run: `cargo test -p context-index discovery::tests exact::tests -- --nocapture`
+
+Expected: all tests pass, including unchanged exact lookup behavior.
+
+- [ ] **Step 6: Commit path refresh**
+
+```bash
+git add crates/context-index/src/discovery.rs
+git commit -m "R5.1-E2 refresh project snapshots by dirty path"
+```
+
+---
+
+### Task 3: Repository Runtime And Initialization
+
+**Files:**
+- Create: `crates/contextd/src/runtime.rs`
+- Modify: `crates/contextd/src/lib.rs`
+- Modify: `crates/contextd/src/main.rs`
+- Modify: `crates/contextd/src/service.rs`
+
+**Interfaces:**
+- Consumes: `RepositoryWatcher`, `DirtyTracker`, `DirtySnapshot`, `ProjectIndexDelta`.
+- Produces: `RepositoryRuntime`, `RuntimeSnapshot`, `RuntimeState`, and test counters.
+- `ContextService::new` performs one full initialization before returning.
+
+- [ ] **Step 1: Add failing runtime state tests**
+
+In `runtime.rs`, add tests for initial unknown state, publish-and-clean acknowledgement, epoch mismatch retaining dirty state, root identity, and five-minute verification expiry using an injected `Instant` argument rather than sleeping.
+
+- [ ] **Step 2: Implement the runtime container**
+
+Use this ownership shape:
+
+```rust
+pub(crate) const FULL_VERIFY_INTERVAL: Duration = Duration::from_secs(300);
+
+pub(crate) struct RuntimeData {
+    pub project: Option<Arc<ProjectIndex>>,
+    pub generation: u64,
+    pub semantic_fingerprint: ModelFingerprint,
+    pub last_full_verified: Option<Instant>,
+    pub discovery_total: u64,
+    pub reconcile_total: u64,
+}
+
+pub(crate) struct RepositoryRuntime {
+    pub root: PathBuf,
+    pub tracker: DirtyTracker,
+    pub watcher: RepositoryWatcher,
+    pub data: std::sync::Mutex<RuntimeData>,
+    pub reconcile_lock: tokio::sync::Mutex<()>,
+}
+```
+
+Provide short synchronous methods to read/publish `Arc<ProjectIndex>`, update totals, test verification expiry, and expose counters under `#[cfg(test)]`. Do not hold the data mutex during discovery, SQLite, retrieval, or embedding.
+
+- [ ] **Step 3: Register the module**
+
+Add `pub mod runtime;` in `lib.rs` and `mod runtime;` in `main.rs` so both library and binary builds use the same source.
+
+- [ ] **Step 4: Add failing initialization test in `service.rs`**
+
+Create a temporary root and construct `ContextService::new(Some(root))`. Assert runtime counters report one discovery and one reconcile before any search. Search once and assert totals do not increase.
+
+- [ ] **Step 5: Replace dead cache ownership and initialize**
+
+Change `ContextService` to:
+
+```rust
+pub struct ContextService {
+    root: PathBuf,
+    explicit_root: Option<PathBuf>,
+    runtime: Arc<RepositoryRuntime>,
+}
+```
+
+Construct the mark-only watcher first, build the service, then invoke a full fast initialization method. Initialization must use current `ProjectIndex::discover`, `StructuralIndex::build_with_delta`, semantic readiness-before-mutation, incremental semantic behavior, generation reads, and epoch acknowledgement.
+
+Remove the `ProjectCache` field/import and adapt `with_cache` tests to an injected runtime constructor rather than retaining dead compatibility code.
+
+- [ ] **Step 6: Run focused service initialization tests**
+
+Run: `cargo test -p contextd service::tests::runtime_initial -- --nocapture`
+
+Expected: initialization counter is one; first clean search does not increment it.
+
+- [ ] **Step 7: Commit runtime initialization**
+
+```bash
+git add crates/contextd/src/runtime.rs crates/contextd/src/lib.rs crates/contextd/src/main.rs crates/contextd/src/service.rs
+git commit -m "R5.1-E2 add persistent repository runtime"
+```
+
+---
+
+### Task 4: Clean And Dirty Query Paths
+
+**Files:**
+- Modify: `crates/contextd/src/runtime.rs`
+- Modify: `crates/contextd/src/service.rs`
+- Modify: `crates/contextd/src/pipeline.rs`
+
+**Interfaces:**
+- Produces: `RuntimeAccess { project, reconcile, generation }` for search/dependency.
+- Produces telemetry fields `reconcile_skipped`, `discovery_calls`, `reconcile_calls`, and `runtime_state`.
+
+- [ ] **Step 1: Add the four clean-path tests**
+
+Add deterministic service tests asserting:
+
+```rust
+assert_eq!(first.stats.discovery_calls, Some(0));
+assert_eq!(first.stats.reconcile_calls, Some(0));
+assert_eq!(first.stats.reconcile_skipped, Some(true));
+assert_eq!(first.stats.runtime_state.as_deref(), Some("clean"));
+assert_eq!(first.stats.generation, second.stats.generation);
+```
+
+Run N=5 clean searches and assert cumulative runtime discovery/reconcile totals remain at initialization values. Run two clean searches with `tokio::join!` and assert the same totals.
+
+- [ ] **Step 2: Add E2 telemetry fields**
+
+Extend `PipelineStats` with nullable serialized fields:
+
+```rust
+pub reconcile_skipped: Option<bool>,
+pub discovery_calls: Option<u32>,
+pub reconcile_calls: Option<u32>,
+pub runtime_state: Option<String>,
+```
+
+Initialize them to `None` in `retrieve_context`; fill them only in service paths.
+
+- [ ] **Step 3: Implement clean runtime access**
+
+Add one service method that acquires `runtime.reconcile_lock`, rechecks dirty state and verification expiry, and immediately returns the current `Arc<ProjectIndex>` when clean. Release the lock before `retrieve_context`.
+
+Clean access reports zero calls and measured zero work; it must not invoke full discovery, structural build, semantic sync, or GC.
+
+- [ ] **Step 4: Add failing dirty create/modify/delete tests**
+
+Use `runtime.tracker.mark_paths` for deterministic state injection after filesystem mutation. Assert:
+
+- one modified file gives `dirty_file_count=1`, `discovery_calls=0`, `reconcile_calls=1`;
+- only that file appears in the reconcile delta;
+- create and delete are visible to exact and structural lookup;
+- deleted symbols, chunks, graph edges, and BM25 rows disappear;
+- generation advances exactly once for a one-file mutation;
+- a no-content-change event does not advance generation;
+- unrelated indexed rows remain unchanged.
+
+- [ ] **Step 5: Implement dirty snapshot reconciliation**
+
+Under the reconcile mutex:
+
+1. snapshot tracker state and epoch;
+2. clone the current `Arc<ProjectIndex>` into a replacement via `refresh_paths`;
+3. run supported paths through `StructuralIndex::update_single_file` inside `spawn_blocking`;
+4. collect actual parsed/deleted paths and structural generation;
+5. preserve semantic readiness-before-mutation;
+6. incrementally synchronize vectors for changed files when previously ready;
+7. GC orphaned vectors after deletions;
+8. publish the replacement snapshot only after all required work succeeds;
+9. acknowledge only the original epoch.
+
+For an exact-only project snapshot mutation with no structural generation change, bump the stored generation once using `structural_store::set_generation` so repository generation remains truthful.
+
+- [ ] **Step 6: Add and pass semantic-ready update/delete tests**
+
+Use `FakeEmbedder` and an initially semantic-ready temporary repository. Modify one file and assert only its changed representations embed, readiness returns true, and unrelated vectors remain. Delete it and assert semantic refs disappear and orphan GC follows existing vector semantics.
+
+- [ ] **Step 7: Add unknown fallback and event-race tests**
+
+Inject `mark_unknown`, search, and assert one discovery/reconcile call. Add a test hook that marks a second event after reconcile snapshot capture but before acknowledgement; assert the runtime remains dirty and the next search processes it. Do not use sleeps.
+
+Also assert public `ContextService::reconcile` forces one full verification, periodic verification expiry changes a clean runtime to the unknown path once, and `full_semantic_index` performs its existing full semantic behavior before publishing a clean replacement snapshot.
+
+- [ ] **Step 8: Adapt dependency to the same runtime access**
+
+Replace `dependency`'s unconditional `reconcile_fast_inner` with the shared runtime access method. Fill the same generation, dirty, discovery, reconcile, skipped, and state telemetry while preserving graph lookup, authority, fusion, and packing behavior.
+
+- [ ] **Step 9: Run focused E2 service tests**
+
+Run: `cargo test -p contextd service::tests -- --nocapture`
+
+Expected: all old service tests plus the 14 E2 cases pass; no ranking assertions change.
+
+- [ ] **Step 10: Commit dirty gating and telemetry**
+
+```bash
+git add crates/contextd/src/runtime.rs crates/contextd/src/service.rs crates/contextd/src/pipeline.rs
+git commit -m "R5.1-E2 dirty-gate repository reconciliation"
+```
+
+---
+
+### Task 5: Benchmark Telemetry Preservation
+
+**Files:**
+- Modify: `bench/adapters/interface.py`
+- Modify: `bench/adapters/context_engine.py`
+- Modify: `bench/adapters/context_engine_hot.py`
+- Modify: `bench/tests/test_run.py`
+
+**Interfaces:**
+- Consumes: serialized E2 `PipelineStats` fields.
+- Produces: matching nullable `SearchResult` fields for both cold CLI and persistent MCP adapters.
+
+- [ ] **Step 1: Add failing adapter telemetry test**
+
+Extend `bench/tests/test_run.py` with a synthetic result containing:
+
+```python
+"reconcileSkipped": True,
+"discoveryCalls": 0,
+"reconcileCalls": 0,
+"runtimeState": "clean",
+```
+
+Assert the `SearchResult` exposes exact values and does not infer them from durations.
+
+- [ ] **Step 2: Run Python tests and confirm red**
+
+Run: `python -m unittest bench.tests.test_run -v`
+
+Expected: failure because the four `SearchResult` fields do not exist.
+
+- [ ] **Step 3: Add nullable fields and map both adapters**
+
+Add:
+
+```python
+reconcile_skipped: Optional[bool] = None
+discovery_calls: Optional[int] = None
+reconcile_calls: Optional[int] = None
+runtime_state: Optional[str] = None
+```
+
+Map snake_case and camelCase variants from engine stats. Keep missing values `None`; never derive a zero from `discovery_ms` or `reconcile_ms`.
+
+- [ ] **Step 4: Run Python tests and compile checks**
+
+Run: `python -m unittest bench.tests.test_run -v`
+
+Run: `python -m py_compile bench/adapters/interface.py bench/adapters/context_engine.py bench/adapters/context_engine_hot.py bench/tests/test_run.py`
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit benchmark telemetry**
+
+```bash
+git add bench/adapters/interface.py bench/adapters/context_engine.py bench/adapters/context_engine_hot.py bench/tests/test_run.py
+git commit -m "R5.1-E2 expose runtime benchmark telemetry"
+```
+
+---
+
+### Task 6: Correctness, Performance, And Final Gates
+
+**Files:**
+- Create ignored artifact: `bench/results/e2_after_<HEAD_SHA>.jsonl`
+- Do not commit unrelated historical `bench/` files.
+
+**Interfaces:**
+- Consumes the same throwaway workload and queries used by the frozen before artifact.
+- Produces final evidence for the required report.
+
+- [ ] **Step 1: Run formatting and focused tests before benchmarking**
+
+Run: `cargo fmt --check`
+
+Run: `cargo test -p context-index watcher::tests -- --nocapture`
+
+Run: `cargo test -p context-index discovery::tests -- --nocapture`
+
+Run: `cargo test -p contextd service::tests -- --nocapture`
+
+Run: `python -m unittest bench.tests.test_run -v`
+
+Expected: all pass.
+
+- [ ] **Step 2: Build the release binary**
+
+Run: `cargo build --release -p contextd`
+
+Expected: exit 0 and `target/release/contextd.exe` updated from current E2 HEAD.
+
+- [ ] **Step 3: Run the identical after workload**
+
+Use the same throwaway runner structure, semantic-disabled environment, official repositories, neutral queries, top_n=5, 11 unchanged samples, and mutation paths recorded in `e2_before_6cdb92e...jsonl`. Write `bench/results/e2_after_<HEAD_SHA>.jsonl`.
+
+Assert every unchanged sample reports:
+
+```text
+discovery_calls=0
+reconcile_calls=0
+reconcile_skipped=true
+dirty_file_count=0
+runtime_state=clean
+```
+
+Assert create/delete/recovery samples report path-local reconcile and clean pinned repositories afterward.
+
+- [ ] **Step 4: Run official 18Q and 26Q protection**
+
+Use the same official/full-corpus, semantic-ready all-minilm 384d representation-v2 configuration as the controlled E1 baseline. Compare every expected-file rank, not only aggregate metrics.
+
+Expected aggregates:
+
+```text
+18Q Hit@1 .500 Hit@3 .611 Hit@5 .611 MRR .556
+26Q Hit@1 .500 Hit@3 .654 Hit@5 .654 MRR .571
+rank differences: NONE
+```
+
+Any rank difference is an architecture bug; do not tune ranking to compensate.
+
+- [ ] **Step 5: Run all required gates**
+
+Run: `cargo fmt --check`
+
+Run: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+
+Run: `cargo test --workspace`
+
+Run: `cargo build --release -p contextd`
+
+Run: `python -m unittest bench.tests.test_run -v`
+
+Run: `git diff --check`
+
+Expected: all exit 0. Record ignored test counts separately; do not claim GitHub CI green.
+
+- [ ] **Step 6: Verify scope and repository cleanliness**
+
+Verify no ranking weights, model identity, representation version, vector search implementation, UI/npm, or out-of-scope files changed. Verify all five pinned repositories are clean and no benchmark probes remain.
+
+- [ ] **Step 7: Request independent code review**
+
+Review the complete range `6cdb92e..HEAD` for correctness, race conditions, invalidation gaps, stale snapshots, transaction/await misuse, and missing required tests. Fix all Critical or Important findings with new commits; do not amend.
+
+- [ ] **Step 8: Stop without PR creation**
+
+Do not push, create or merge a PR, or start E3. Produce the exact `R5.1-E2 PERSISTENT RUNTIME REPORT` structure from the user requirements and end with `R5.1_E2_READY_FOR_REVIEW` or `R5.1_E2_BLOCKED`.

--- a/docs/superpowers/specs/2026-08-18-r5.1-e2-persistent-runtime-design.md
+++ b/docs/superpowers/specs/2026-08-18-r5.1-e2-persistent-runtime-design.md
@@ -1,0 +1,221 @@
+# R5.1-E2 Persistent Repository Runtime Design
+
+## Goal
+
+Make a persistent MCP repository service reuse a validated in-memory project snapshot. An unchanged hot query must perform zero full repository discoveries and zero reconciles. File changes remain correct through dirty-path reconciliation, while watcher uncertainty falls back to bounded full verification.
+
+E2 does not change retrieval, ranking, authority, embedding identity, or vector search design.
+
+## Current State
+
+`McpAdapter` owns one `Arc<ContextService>` for the process, but `ContextService::search` currently performs this work on every call:
+
+1. Resolve the same root.
+2. Run `ProjectIndex::discover`, including the full walk and hash pass.
+3. Run `StructuralIndex::build_with_delta` over the repository.
+4. Check and synchronize semantic state.
+5. Retrieve and rank results.
+
+The existing `ProjectCache` is unused and its `ensure` method always rediscovers, so it is not a useful runtime boundary.
+
+The existing `StructuralWatcher` updates SQLite from its own worker. It is not suitable for direct service integration because it does not share `ContextService` reconciliation locking, does not refresh the exact-search `ProjectIndex`, and does not coordinate semantic updates.
+
+## Repository Runtime
+
+`ContextService` will own one repository-scoped `RepositoryRuntime`. It is not global and never spans roots or worktrees.
+
+The runtime contains:
+
+- the canonical repository root;
+- an `Arc<ProjectIndex>` validated snapshot;
+- the indexed generation associated with that snapshot;
+- the configured semantic fingerprint;
+- dirty state and watcher event epoch;
+- the last successful full verification time;
+- the existing async reconciliation mutex;
+- a mark-only filesystem watcher kept alive for the runtime lifetime.
+
+The snapshot uses `Arc<ProjectIndex>` so clean concurrent searches clone an `Arc`, not the full file vector, and do not hold a lock during retrieval. A dirty reconcile creates and publishes a replacement snapshot after all required updates succeed.
+
+`ProjectCache` will be removed rather than extended. It has no production callers and keeping two ownership models would make invalidation ambiguous.
+
+## Dirty State
+
+The watcher maintains one bounded state:
+
+- `Clean`: no observed path changes since the published snapshot.
+- `Dirty(paths)`: a deterministic sorted set of changed or deleted relative paths.
+- `Unknown`: path-level events cannot prove completeness.
+
+Every accepted watcher event increments a monotonic epoch. Reconciliation snapshots both the state and epoch without clearing them. After successful reconciliation, it marks the state clean only if the epoch is unchanged. If any event arrives during reconciliation, acknowledgement does not clear state, including when the new event names a path already in the snapshot. This may safely repeat work once but cannot lose a modification.
+
+The mark-only watcher performs no parsing, indexing, embedding, or SQLite writes from notify callbacks or background workers.
+
+## Watcher Classification
+
+Regular file create, modify, remove, and rename paths become `Dirty(paths)` after root-relative normalization and engine-internal filtering.
+
+The state becomes `Unknown` when:
+
+- the notify callback reports an error;
+- the bounded event channel or state capacity overflows;
+- an event cannot be normalized under the explicit root;
+- a directory event can affect an unknown set of descendants;
+- `.gitignore`, `.ignore`, or `.opencodeignore` changes;
+- the watcher reports a rescan requirement.
+
+The existing auto-indexing `StructuralWatcher` remains unchanged for compatibility. E2 adds a small mark-only watcher in `context-index` and reuses the existing normalization and ignore rules where possible.
+
+Watcher construction failure makes `ContextService::new` fail. The service must not claim a clean persistent runtime without any invalidation source.
+
+## Initialization
+
+`ContextService::new` performs repository initialization before MCP readiness:
+
+1. Resolve and canonicalize the explicit root.
+2. Start the mark-only watcher in `Unknown` state.
+3. Perform one full `ProjectIndex::discover`.
+4. Run existing structural/BM25/graph reconciliation.
+5. Apply existing fast semantic synchronization and GC rules.
+6. Read the resulting generation and publish the project snapshot.
+7. Mark clean only if the watcher epoch did not change during initialization.
+
+Initialization cost belongs to service startup, not the first ready query. CLI commands still use the same `ContextService`; their process wall time includes service startup, while query telemetry remains scoped to the query.
+
+## Clean Search
+
+A clean search performs:
+
+1. Normalize/classify the query as today.
+2. Read the watcher snapshot and runtime metadata under a short lock.
+3. Clone the current `Arc<ProjectIndex>`.
+4. Run the unchanged retrieval, fusion, authority, and packing pipeline.
+
+It does not call `ProjectIndex::discover`, `StructuralIndex::build_with_delta`, or any semantic reconciliation function.
+
+Clean telemetry is explicit:
+
+- `discovery_calls = 0`;
+- `discovery_ms = 0` because no discovery work ran;
+- `reconcile_calls = 0`;
+- `reconcile_ms = 0` because no reconcile work ran;
+- `reconcile_skipped = true`;
+- `dirty_file_count = 0`;
+- `runtime_state = "clean"`;
+- `generation` is the published runtime generation.
+
+## Dirty Reconcile
+
+Only one task may reconcile a repository at a time. A caller that acquires the reconciliation mutex rechecks state because another caller may already have completed the work.
+
+For `Dirty(paths)`:
+
+1. Snapshot paths and epoch.
+2. Capture semantic readiness before structural mutation.
+3. Refresh only those records in a replacement `ProjectIndex`; unrelated files are not walked or rehashed.
+4. For structurally supported paths, call the existing hash-verified single-file structural API. This transactionally updates files, symbols, chunks, BM25, and graph edges.
+5. Collect actual changed and deleted paths from structural results.
+6. If the repository was semantic-ready, run existing incremental semantic synchronization for changed files.
+7. Run existing orphan vector GC after deletions.
+8. Read the resulting generation and publish the replacement project snapshot.
+9. Acknowledge the watcher snapshot only when its epoch is unchanged.
+
+The single-file API may advance generation once per real path mutation. No-change events do not advance generation. The one-file benchmark therefore advances generation exactly once.
+
+Failures do not publish a replacement snapshot or acknowledge dirty state. The next request retries safely.
+
+## Unknown Reconcile And Verification
+
+`Unknown` performs the same full discovery and reconciliation used for initialization. Full discovery is required only for:
+
+- initial service construction;
+- watcher overflow, error, rescan, directory uncertainty, or ignore-rule changes;
+- explicit `ContextService::reconcile`;
+- full semantic indexing;
+- bounded periodic verification.
+
+Clean runtimes receive a query-gated full verification no more than once every five minutes. There is no polling loop. This bounds silent watcher-loss exposure without restoring a full walk on every query. Tests use explicit unknown injection instead of waiting for the interval.
+
+If an event arrives during full verification, epoch acknowledgement fails and the runtime remains dirty or unknown.
+
+## Project Snapshot Updates
+
+`ProjectIndex` gains a deterministic path-refresh operation that applies the same classification, generated-file exclusion, size cap, metadata, and hashing rules as full discovery for only the supplied paths. It removes deleted or newly excluded paths, inserts or replaces eligible files, recomputes aggregate scan statistics, and preserves sorted path order.
+
+Ignore-file and directory changes never use path refresh; they force `Unknown` because their effects are not path-local.
+
+## Concurrency And Locks
+
+Lock order is fixed:
+
+1. reconciliation mutex;
+2. brief watcher/runtime state mutexes;
+3. SQLite connection or transaction inside blocking work.
+
+Clean retrieval holds none of these locks after cloning the project snapshot.
+
+Dirty and unknown reconciles use `spawn_blocking` for discovery, parsing, hashing, and SQLite structural work. Rusqlite connections remain task-local and are never shared between threads.
+
+No SQLite transaction is held across embedding HTTP requests. Existing semantic functions may retain a connection, but must not retain an active transaction while awaiting the embedder.
+
+Concurrency behavior:
+
+- concurrent clean searches share the snapshot and run retrieval concurrently;
+- a search encountering dirty state performs one reconcile;
+- other dirty callers wait, recheck, and skip duplicate work;
+- an event during reconcile remains pending through epoch mismatch;
+- unknown state serializes one full fallback reconcile.
+
+## Telemetry
+
+`PipelineStats` adds nullable serialized fields:
+
+- `reconcile_skipped`;
+- `discovery_calls`;
+- `reconcile_calls`;
+- `runtime_state`.
+
+Existing stage fields remain unchanged. Values are real counters and booleans, not inferred by benchmark code. `cache_hit` remains null because E2 adds no result cache.
+
+Dirty reconcile telemetry records the dirty path count observed at reconcile start. Unknown reconcile reports the full fallback state and one discovery/reconcile call. If a metric is unavailable, it remains null rather than a fake zero.
+
+## Correctness Tests
+
+Deterministic tests cover:
+
+1. initialization performs one discovery;
+2. the second clean search performs zero discoveries;
+3. repeated clean searches remain at zero discoveries;
+4. one modified file becomes dirty;
+5. only the modified file is reconciled;
+6. deletion removes structural, BM25, graph, and semantic references;
+7. real mutation advances generation;
+8. no-change query does not advance generation;
+9. unknown state performs a safe full fallback;
+10. an event during reconcile is not acknowledged away;
+11. concurrent clean searches do not reconcile;
+12. explicit roots/worktrees remain isolated;
+13. semantic-ready one-file update remains ready and embeds only required representations;
+14. representative retrieval goldens preserve results.
+
+Existing watcher, structural, vector, and retrieval tests remain enabled and unchanged unless an assertion must include new telemetry.
+
+## Benchmark And Acceptance
+
+The frozen before artifact is:
+
+`bench/results/e2_before_6cdb92ebe14939568cf0339138e7c0b5d283c011.jsonl`
+
+The after workload uses the same repositories, neutral queries, semantic-disabled performance environment, persistent MCP process, 11 unchanged samples, and create/delete/recovery probes.
+
+Primary acceptance:
+
+- unchanged hot query: zero full discoveries;
+- unchanged hot query: zero reconciles;
+- no rank differences in the controlled official 18Q and 26Q evaluations.
+
+Cold initialization, unchanged hot, one-file dirty, and delete/recovery timings remain separate.
+
+## Out Of Scope
+
+E2 does not add result caching, ANN/HNSW, a hot vector store, vector mmap changes, embedding model changes, ranking changes, LSP/SCIP, multi-repository services, editing tools, UI work, CI repair, or E3 functionality.


### PR DESCRIPTION
## **User description**
## R5.1-E2 — Persistent Repository Runtime

### Goal

Eliminate full repository discovery/reconciliation from unchanged persistent hot queries.

Before E2:

- persistent hot search still performed one repository discovery/reconcile cycle

After E2:

- clean unchanged hot search performs zero full discoveries
- zero reconciles
- runtime reuses persistent repository state
- file mutations reconcile incrementally
- UNKNOWN/watcher recovery safely falls back to a full verification

### Architecture

Adds repository-scoped persistent runtime state owned by ContextService.

Runtime tracks:

- repository generation
- clean/dirty/unknown state
- changed/deleted files
- watcher-derived invalidation
- incremental reconciliation state

Normal clean hot path:

query
→ RepositoryRuntime CLEAN
→ skip discovery
→ skip reconcile
→ retrieve
→ rank/fuse
→ pack

Full discovery remains intentionally available for:

- initial initialization
- UNKNOWN state
- watcher recovery
- bounded safety recovery

### Hot-path proof

Across 36/36 repeated-hot samples (3 repos × 12: first_hot + 11 repeated):

- discovery_calls = 0
- reconcile_calls = 0
- reconcile_skipped = true
- dirty_file_count = 0
- runtime_state = clean

Explicit file create (probe __bench_e2_probe__):

- discovery_calls = 0
- reconcile_calls = 1
- runtime_state = dirty
- path-local refresh via IncrementalIgnore + symlink guard

Ambiguous removes (Remove(Any)/Remove(Other)) — directories with dots like src/v1.2, packages/foo.bar, or generic name events:

- conservatively MarkUnknown
- next access → exactly one safe full discovery/reconcile (discovery_calls=1, runtime_state=unknown)
- Correctness > avoiding one fallback discovery. Explicit Remove(File) and Remove(Folder) retain precise handling.

All five original CodeAnt findings fixed:

- incremental .gitignore/.ignore/.opencodeignore parity via WalkBuilder build_matchers
- symlink/component guard before metadata/hashing
- watcher .opencode/index vs .opencode/settings parity
- generic directory rename/remove → Unknown
- Index command single-pass (new_for_index)

Ambiguous generic remove now intentionally falls back to UNKNOWN (extension heuristic removed).

### Performance

IMPORTANT:
These E1→E2 latency measurements use the same semantic-disabled performance workload (CONTEXTD_SEMANTIC_ENABLED=0, all-minilm model not used, representation v2, official/full state, top_n=5, neutral queries per repo).
They measure persistent-runtime/discovery architecture, not final semantic-on production latency.

Repeated-hot wall p50 / p95 at final HEAD 092a62c83f04c1b1bdcde1346fc31e2a2fb13eed (ContextEngineHotAdapter/MCP persistent per repo, semantic disabled):

#### Django (query: Where is Model implemented?, delete django/utils/text.py)

Before (6cdb92e):
13,414 / 25,135 ms

After (092a62c):
2,093 / 2,237 ms

Delta:
-84.4% p50
-91.1% p95

#### NestJS (query: Where is NestFactory implemented?, delete packages/core/test/injector/module.spec.ts)

Before:
4,296 / 4,635 ms

After:
682 / 743 ms

Delta:
-84.1% p50
-84.0% p95

#### ripgrep (query: Where is Searcher implemented?, delete crates/globset/src/lib.rs)

Before:
1,738 / 1,916 ms

After:
589 / 642 ms

Delta:
-66.1% p50
-66.5% p95

Clean repeated hot verifies 0 discovery / 0 reconcile across all 36 samples. Mutation probe_create remains path-local 0/1; ambiguous probe_remove/delete/restore conservatively 1/1 Unknown as designed.

Final benchmark artifact:

bench/results/e2_after_092a62c83f04c1b1bdcde1346fc31e2a2fb13eed.jsonl

Generated via throwaway runner C:\Users\Dell\AppData\Local\Temp\opencode\e2_after_runner.py at exact HEAD 092a62c with binary C:\Users\Dell\context\Context-Engine\target\release\contextd.exe (built from that HEAD), CONTEXTD_SEMANTIC_ENABLED=0, top_n=5, official profile, 11x repeated hot per repo.

### Correctness

Controlled official/full-corpus correctness with semantic-ready all-minilm 384d representation v2, actually executed at exact final HEAD 092a62c (binary built from that HEAD). Command: `python bench/scripts/run.py --adapters context_engine --profile official --top-n 5 --output bench/results/e2_control_official_ready_26q_092a62c83f04c1b1bdcde1346fc31e2a2fb13eed.jsonl`

18Q:

- Hit@1 .500
- Hit@3 .611
- Hit@5 .611
- MRR .556

26Q:

- Hit@1 .500
- Hit@3 .654
- Hit@5 .654
- MRR .571

Expected-file rank differences versus E1 (e1_control_official_ready_26q_6cdb92e.jsonl):

0 / 26

Correctness artifact (genuine run, not copied):

bench/results/e2_control_official_ready_26q_092a62c83f04c1b1bdcde1346fc31e2a2fb13eed.jsonl (56474 bytes, 26 queries, 5 repos: django, gin, lodash, nestjs, ripgrep; profile official)

All five pinned repository indexes reported at init:

- semanticIndexReady=true
- missingVectorCount=0
- eligibleChunkCount=semanticRefCount

### Safety / correctness

Verified:

- dirty-state correctness (epoch, overflow Unknown, empty no-op)
- watcher normalization (ParentDir -> Unknown)
- .opencode/index parity and ignored .context/.git still Noop
- dotted directory ambiguous removes (src/v1.2, packages/foo.bar) -> Unknown
- explicit Remove(File) remains path-local, Remove(Folder) Unknown, Rename Unknown
- event-during-reconcile handling (epoch mismatch retains dirty)
- repository generation correctness (path-local bump, full discovery)
- explicit worktree/root isolation
- concurrent hot searches keep counters unchanged
- no lost dirty events
- safe UNKNOWN fallback (one full discovery)
- no hidden full discovery on normal clean search
- no ranking/fusion/model/representation changes

### Gates

- cargo fmt --all -- --check: PASS
- cargo clippy --workspace --all-targets --all-features -- -D warnings: PASS
- cargo test --workspace: PASS (142 context-index + 48 context-rank + 40 contextd lib + 40 contextd bin + 12 test_retrieval, 0 failed, ignored 22)
- cargo build --release -p contextd: PASS
- python -m unittest bench.tests.test_run -v: PASS, 6 tests
- git diff --check: PASS
- five pinned benchmark repositories clean (git status --porcelain empty after after-run)

### Out of scope

No:

- ranking changes
- ANN / HNSW
- result cache
- hot vector redesign
- LSP / SCIP
- embedding model changes
- benchmark hardcoding

This PR is limited to persistent repository runtime, dirty-state tracking, watcher-backed invalidation (now conservative for ambiguous removes), and dirty-gated reconciliation.
